### PR TITLE
change "a" before "NFC" to "an"

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Use Eve or a similar app to create automations like these:
 
 (3) AirPlay 2 speaker like HomePod required.
 
-**Important:** Use a NFC tag to arm/disarm the security system easily and securely without using the Home app.
+**Important:** Use an NFC tag to arm/disarm the security system easily and securely without using the Home app.
 
 ## General options
 


### PR DESCRIPTION
I know you're thinking, _NFC starts with a consonant, so of course it uses an "a" and not an "an"_. However, the a/an is determined based on the sound of the word, not necessarily the letter. As NFC is an acronym, so we pronounce it _En eff see_, the **sound** the words begins with is a vowel sound, and thus "NFC" should be preceded by an "an".



Further info:
https://www.merriam-webster.com/words-at-play/is-it-a-or-an
https://www.dictionary.com/e/a-vs-an/
https://writingexplained.org/a-vs-an-difference
https://www.grammar.com/a-vs-an-when-to-use/