### PR TITLE
ci: add artifact attestation to build workflow

### DIFF
--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -15,6 +15,10 @@ jobs:
   build-package:
     name: Build package
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
 
     steps:
       - name: Checkout repository
@@ -28,4 +32,11 @@ jobs:
           registry-url: https://registry.npmjs.org/
 
       - name: Build package
-        run: npm ci
+        run: |
+          npm ci
+          npm pack
+
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@v3
+        with:
+          subject-path: "*.tgz"

--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -37,6 +37,7 @@ jobs:
           npm pack
 
       - name: Attest build provenance
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
         uses: actions/attest-build-provenance@v3
         with:
           subject-path: "*.tgz"


### PR DESCRIPTION
## Summary
- attest build artifacts using `actions/attest-build-provenance`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bd8d77db1083278011a67fc7d3bea2