### PR TITLE
ci: set setup-node version from repository variable

### DIFF
--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -28,6 +28,7 @@ jobs:
         uses: actions/setup-node@v6
 
         with:
+          node-version: ${{ vars.NPM_VERSION }}
           cache: "npm"
           registry-url: https://registry.npmjs.org/
 

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -31,6 +31,8 @@ jobs:
 
       - name: Setup node
         uses: actions/setup-node@v6
+        with:
+          node-version: ${{ vars.NPM_VERSION }}
 
       - name: Get next version
         uses: MiguelRipoll23/get-next-version@v3.0.0

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -71,6 +71,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v6
         with:
+          node-version: ${{ vars.NPM_VERSION }}
           registry-url: https://registry.npmjs.org/
 
       - name: Get version


### PR DESCRIPTION
### Motivation
- Centralize the Node.js version for CI by sourcing it from the repository variable `NPM_VERSION` so workflows stay consistent and can be updated without changing multiple files.
- Apply the change to the workflows that invoke `actions/setup-node@v6` to ensure all build, bump, and publish flows use the same configured Node version.

### Description
- Added `node-version: ${{ vars.NPM_VERSION }}` to the `actions/setup-node@v6` step in ` .github/workflows/build-package.yml`, ` .github/workflows/bump-version.yml`, and ` .github/workflows/publish.yml`.
- No skills from `AGENTS.md` were required or used because this was a direct workflow configuration change.

### Testing
- Ran `rg -n "actions/setup-node|node-version" .github/workflows` to confirm the `node-version` entries were added and the command completed successfully.
- Inspected the updated workflow files with `nl`/`sed` to verify the `node-version` lines are present in each modified file.
- Executed `git status` and committed the changes to confirm a clean edit and successful commit.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a3623b83748327912fc41be06f363c)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated CI/CD workflows to use a centralized Node.js version configuration, ensuring consistent versions across build, deployment, and publishing processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->