### PR TITLE
fix: install dependencies before publishing package

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -74,6 +74,9 @@ jobs:
           node-version: ${{ vars.NPM_VERSION }}
           registry-url: https://registry.npmjs.org/
 
+      - name: Install dependencies
+        run: npm ci
+
       - name: Get version
         run: |
           echo "NPM_VERSION=${{ needs.create-tag.outputs.tag-name }}" >> $GITHUB_ENV


### PR DESCRIPTION
## Summary
- Adds `npm ci` step to the `publish-package` job before `npm publish`
- Fixes `eslint: not found` error caused by missing dev dependencies when `prepublishOnly` runs

## Test plan
- [ ] Trigger a publish workflow and verify `prepublishOnly` (lint + build) completes successfully

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated publishing workflow to ensure Node dependencies are installed before package release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->