### PR TITLE
fix: skip lib check to avoid errors in @matter/types declarations

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,8 @@
     "sourceMap": true,
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
-    "forceConsistentCasingInFileNames": true
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true
   },
   "include": [
     "eslint.config.js",


### PR DESCRIPTION
## Summary
- Adds `skipLibCheck: true` to `tsconfig.json`
- Fixes TypeScript errors in `node_modules/@matter/types` declaration files (TS1036, TS1038) that break the build step during publish

## Test plan
- [ ] Trigger a publish workflow and verify the build step completes without TypeScript errors