### PR TITLE
refactor: remove duplicate modeToStateVal and calcAvailableStates utilities

### DIFF
--- a/src/conditions/double-knock-condition.ts
+++ b/src/conditions/double-knock-condition.ts
@@ -19,9 +19,11 @@ export class DoubleKnockCondition extends Condition {
    * @param onFirstKnock Called when the first knock is detected.
    *   The callback receives the window duration in seconds and a reset function
    *   to invoke when the window expires.
+   * @param onCancelTimer Called on the second knock to cancel the running window timer.
    */
   constructor(
     private readonly onFirstKnock: (seconds: number, onExpire: () => void) => void,
+    private readonly onCancelTimer: () => void,
   ) {
     super();
   }
@@ -43,12 +45,9 @@ export class DoubleKnockCondition extends Condition {
     }
 
     if (state.isKnocked) {
-      // Second knock — clear the flag and allow through.
+      // Second knock — clear the flag and cancel the window timer, then allow through.
       state.isKnocked = false;
-      if (state.doubleKnockTimeout !== null) {
-        clearTimeout(state.doubleKnockTimeout);
-        state.doubleKnockTimeout = null;
-      }
+      this.onCancelTimer();
       return false;
     }
 
@@ -58,7 +57,6 @@ export class DoubleKnockCondition extends Condition {
 
     this.onFirstKnock(seconds, () => {
       state.isKnocked = false;
-      state.doubleKnockTimeout = null;
       log.info('Trip Switch (Reset): double-knock window expired without second activation');
     });
 

--- a/src/conditions/trigger-already-running-condition.ts
+++ b/src/conditions/trigger-already-running-condition.ts
@@ -12,7 +12,7 @@ export class TriggerAlreadyRunningCondition extends Condition {
     if (!value) {
       return false;
     }
-    if (state.triggerTimeout !== null) {
+    if (state.isTripping) {
       log.warn('Security System (Already tripped): trigger delay countdown is already running');
       return true;
     }

--- a/src/handlers/state-handler.ts
+++ b/src/handlers/state-handler.ts
@@ -15,6 +15,7 @@ import type { TripHandler } from './trip-handler.js';
 import type { SwitchHandler } from './switch-handler.js';
 import type { SensorHandler } from './sensor-handler.js';
 import type { TimerManager } from '../timers/timer-manager.js';
+import { getArmingSeconds } from '../utils/arming-util.js';
 
 /** Manages the core security-system state machine: arming, triggering, and resetting. */
 export class StateHandler {
@@ -103,25 +104,8 @@ export class StateHandler {
     return true;
   }
 
-  getArmingSeconds(state: SecurityState): number {
-    const isTriggered = this.state.currentState === SecurityState.TRIGGERED;
-    const isOff = state === SecurityState.OFF;
-
-    if (isTriggered || isOff) {
-      return 0; 
-    }
-
-    if (state === SecurityState.HOME && this.options.homeArmSeconds !== null) {
-      return this.options.homeArmSeconds;
-    }
-    if (state === SecurityState.AWAY && this.options.awayArmSeconds !== null) {
-      return this.options.awayArmSeconds;
-    }
-    if (state === SecurityState.NIGHT && this.options.nightArmSeconds !== null) {
-      return this.options.nightArmSeconds;
-    }
-
-    return this.options.armSeconds;
+  getArmingSeconds(targetState: SecurityState): number {
+    return getArmingSeconds(this.state, this.options, targetState);
   }
 
   resetTimers(): void {

--- a/src/handlers/state-handler.ts
+++ b/src/handlers/state-handler.ts
@@ -14,6 +14,7 @@ import type { AudioService } from '../services/audio-service.js';
 import type { TripHandler } from './trip-handler.js';
 import type { SwitchHandler } from './switch-handler.js';
 import type { SensorHandler } from './sensor-handler.js';
+import type { TimerManager } from '../timers/timer-manager.js';
 
 /** Manages the core security-system state machine: arming, triggering, and resetting. */
 export class StateHandler {
@@ -30,6 +31,7 @@ export class StateHandler {
     private readonly bus: EventBusService,
     private readonly storageService: StorageService,
     private readonly audio: AudioService,
+    private readonly timers: TimerManager,
   ) {}
 
   setHandlers(trip: TripHandler, sw: SwitchHandler, sensor: SensorHandler): void {
@@ -93,11 +95,10 @@ export class StateHandler {
     this.handleArmingState();
     this.log.info(`Arm delay (${armSeconds}s)`);
 
-    this.state.armTimeout = setTimeout(() => {
-      this.state.armTimeout = null;
+    this.timers.setArmTimer(armSeconds * 1000, () => {
       this.state.isArming = false;
       this.setCurrentState(state, origin);
-    }, armSeconds * 1000);
+    });
 
     return true;
   }
@@ -124,41 +125,12 @@ export class StateHandler {
   }
 
   resetTimers(): void {
-    if (this.state.triggerTimeout) {
-      clearTimeout(this.state.triggerTimeout);
-      this.state.triggerTimeout = null;
-      this.log.debug('Trigger timeout (Cleared)');
-    }
-    if (this.state.armTimeout) {
-      clearTimeout(this.state.armTimeout);
-      this.state.armTimeout = null;
-      this.log.debug('Arming timeout (Cleared)');
-    }
-    if (this.state.triggeredMotionSensorInterval) {
-      clearInterval(this.state.triggeredMotionSensorInterval);
-      this.state.triggeredMotionSensorInterval = null;
-      this.log.debug('Triggered interval (Cleared)');
-    }
-    if (this.state.trippedMotionSensorInterval) {
-      clearInterval(this.state.trippedMotionSensorInterval);
-      this.state.trippedMotionSensorInterval = null;
-      this.log.debug('Tripped interval (Cleared)');
-    }
-    if (this.state.doubleKnockTimeout) {
-      clearTimeout(this.state.doubleKnockTimeout);
-      this.state.doubleKnockTimeout = null;
-      this.log.debug('Double-knock timeout (Cleared)');
-    }
-    if (this.state.pauseTimeout) {
-      clearTimeout(this.state.pauseTimeout);
-      this.state.pauseTimeout = null;
-      this.log.debug('Pause timeout (Cleared)');
-    }
-    if (this.state.resetTimeout) {
-      clearTimeout(this.state.resetTimeout);
-      this.state.resetTimeout = null;
-      this.log.debug('Reset timeout (Cleared)');
-    }
+    this.timers.clearAll();
+  }
+
+  /** Returns true while the trigger delay is counting down (trip switch is active). */
+  isTripping(): boolean {
+    return this.state.isTripping;
   }
 
   getAvailableTargetStates(): SecurityState[] {
@@ -227,20 +199,16 @@ export class StateHandler {
   }
 
   private handleTriggeredState(): void {
-    if (this.state.trippedMotionSensorInterval) {
-      clearInterval(this.state.trippedMotionSensorInterval);
-      this.state.trippedMotionSensorInterval = null;
-    }
+    this.timers.clearTrippedInterval();
 
     if (this.options.triggeredMotionSensor) {
-      this.state.triggeredMotionSensorInterval = setInterval(
-        () => this.sensorHandler.pulseTriggeredMotionSensor(),
+      this.timers.setTriggeredInterval(
         this.options.triggeredMotionSensorSeconds * 1000,
+        () => this.sensorHandler.pulseTriggeredMotionSensor(),
       );
     }
 
-    this.state.resetTimeout = setTimeout(() => {
-      this.state.resetTimeout = null;
+    this.timers.setResetTimer(this.options.resetMinutes * 60 * 1000, () => {
       this.log.info('Reset (Finished)');
       this.sensorHandler.pulseResetMotionSensor();
 
@@ -249,7 +217,7 @@ export class StateHandler {
       } else {
         this.setCurrentState(this.state.targetState, OriginType.EXTERNAL);
       }
-    }, this.options.resetMinutes * 60 * 1000);
+    });
   }
 
   private handleArmingState(): void {

--- a/src/handlers/state-handler.ts
+++ b/src/handlers/state-handler.ts
@@ -11,18 +11,16 @@ import type { EventBusService } from '../services/event-bus-service.js';
 import { EventType } from '../types/event-type.js';
 import type { StorageService } from '../services/storage-service.js';
 import type { AudioService } from '../services/audio-service.js';
-import type { TripHandler } from './trip-handler.js';
-import type { SwitchHandler } from './switch-handler.js';
 import type { SensorHandler } from './sensor-handler.js';
 import type { TimerManager } from '../timers/timer-manager.js';
 import { getArmingSeconds } from '../utils/arming-util.js';
 
-/** Manages the core security-system state machine: arming, triggering, and resetting. */
+/**
+ * Manages the core security-system state machine: arming, triggering, and resetting.
+ * Cross-handler side effects are signalled via the event bus so that this class has
+ * no direct dependencies on TripHandler or SwitchHandler.
+ */
 export class StateHandler {
-  private tripHandler!: TripHandler;
-  private switchHandler!: SwitchHandler;
-  private sensorHandler!: SensorHandler;
-
   constructor(
     private readonly services: ServiceRegistry,
     private readonly state: SystemState,
@@ -33,13 +31,8 @@ export class StateHandler {
     private readonly storageService: StorageService,
     private readonly audio: AudioService,
     private readonly timers: TimerManager,
+    private readonly sensorHandler: SensorHandler,
   ) {}
-
-  setHandlers(trip: TripHandler, sw: SwitchHandler, sensor: SensorHandler): void {
-    this.tripHandler = trip;
-    this.switchHandler = sw;
-    this.sensorHandler = sensor;
-  }
 
   // ── Public API ─────────────────────────────────────────────────────────────
 
@@ -65,7 +58,7 @@ export class StateHandler {
 
   updateTargetState(state: SecurityState, origin: OriginType, delay: number): boolean {
     if (this.isBadTargetState(state)) {
-      return false; 
+      return false;
     }
 
     this.state.targetState = state;
@@ -117,6 +110,24 @@ export class StateHandler {
     return this.state.isTripping;
   }
 
+  /** Checks whether arming is currently blocked by an arming-lock switch. */
+  isArmingLocked(targetState: SecurityState): boolean {
+    if (this.services.armingLockSwitchService.getCharacteristic(this.Characteristic.On).value) {
+      return true;
+    }
+
+    const modeMap: Partial<Record<SecurityState, keyof ServiceRegistry>> = {
+      [SecurityState.HOME]: 'armingLockHomeSwitchService',
+      [SecurityState.AWAY]: 'armingLockAwaySwitchService',
+      [SecurityState.NIGHT]: 'armingLockNightSwitchService',
+    };
+
+    const svcKey = modeMap[targetState];
+    return svcKey
+      ? Boolean(this.services[svcKey].getCharacteristic(this.Characteristic.On).value)
+      : false;
+  }
+
   getAvailableTargetStates(): SecurityState[] {
     const all = [SecurityState.HOME, SecurityState.AWAY, SecurityState.NIGHT, SecurityState.OFF];
     const disabled = this.options.disabledModes.map(m => modeToState(m.toLowerCase()));
@@ -145,7 +156,7 @@ export class StateHandler {
     }
 
     const hasLock = this.options.armingLockSwitch || this.options.armingLockSwitches;
-    if (state !== SecurityState.OFF && hasLock && this.switchHandler.isArmingLocked(state)) {
+    if (state !== SecurityState.OFF && hasLock && this.isArmingLocked(state)) {
       this.log.warn('Arming lock (Not allowed)');
       return true;
     }
@@ -155,10 +166,12 @@ export class StateHandler {
 
   private handleTargetStateChange(origin: OriginType): void {
     this.resetTimers();
-    this.tripHandler.resetTripSwitches();
+
+    // Notify handlers to reset their displayed state (bus is synchronous).
+    this.bus.emit(EventType.RESET_TRIP_SWITCHES, {});
     this.sensorHandler.resetTrippedMotionSensor();
-    this.switchHandler.resetModeSwitches();
-    this.switchHandler.updateModeSwitches();
+    this.bus.emit(EventType.RESET_MODE_SWITCHES, {});
+    this.bus.emit(EventType.UPDATE_MODE_SWITCHES, {});
 
     this.bus.emit(EventType.TARGET_CHANGED, { state: this.state.targetState, origin });
 
@@ -174,11 +187,12 @@ export class StateHandler {
       this.handleTriggeredState();
 
       if (this.options.testMode) {
-        return; 
+        return;
       }
     }
 
-    this.tripHandler.resetTripSwitches();
+    // Notify TripHandler to reset trip switches on any state change.
+    this.bus.emit(EventType.RESET_TRIP_SWITCHES, {});
     this.bus.emit(EventType.CURRENT_CHANGED, { state: this.state.currentState, origin });
   }
 

--- a/src/handlers/switch-handler.ts
+++ b/src/handlers/switch-handler.ts
@@ -9,11 +9,15 @@ import type { StateHandler } from './state-handler.js';
 import { OriginType } from '../types/origin-type.js';
 import { capitalise } from '../utils/state-util.js';
 import type { TimerManager } from '../timers/timer-manager.js';
+import type { EventBusService } from '../services/event-bus-service.js';
+import { EventType } from '../types/event-type.js';
 
-/** Handles all mode switches, arming-lock switches, and the pause/extended switches. */
+/**
+ * Handles all mode switches and the pause/extended switches.
+ * Calls StateHandler directly (one-way dependency — no cycle).
+ * Subscribes to bus events emitted by StateHandler to reset its own display state.
+ */
 export class SwitchHandler {
-  private stateHandler!: StateHandler;
-
   constructor(
     private readonly services: ServiceRegistry,
     private readonly state: SystemState,
@@ -21,17 +25,20 @@ export class SwitchHandler {
     private readonly Characteristic: CharacteristicConstructor,
     private readonly log: Logging,
     private readonly timers: TimerManager,
+    private readonly stateHandler: StateHandler,
   ) {}
 
-  setStateHandler(handler: StateHandler): void {
-    this.stateHandler = handler;
+  /** Register bus listeners so StateHandler can signal display resets without importing this class. */
+  subscribeToStateEvents(bus: EventBusService): void {
+    bus.on(EventType.RESET_MODE_SWITCHES, () => this.resetModeSwitches());
+    bus.on(EventType.UPDATE_MODE_SWITCHES, () => this.updateModeSwitches());
   }
 
   // ── Mode switches ──────────────────────────────────────────────────────────
 
   setModeSwitch(mode: SecurityState, value: boolean): number | null {
     if (!value) {
-      return HK_NOT_ALLOWED_IN_CURRENT_STATE; 
+      return HK_NOT_ALLOWED_IN_CURRENT_STATE;
     }
     const delay = this.stateHandler.getArmingSeconds(mode);
     this.stateHandler.updateTargetState(mode, OriginType.INTERNAL, delay);
@@ -40,7 +47,7 @@ export class SwitchHandler {
 
   setModeOffSwitch(value: boolean): number | null {
     if (!value) {
-      return HK_NOT_ALLOWED_IN_CURRENT_STATE; 
+      return HK_NOT_ALLOWED_IN_CURRENT_STATE;
     }
     this.stateHandler.updateTargetState(SecurityState.OFF, OriginType.INTERNAL, 0);
     return null;
@@ -48,7 +55,7 @@ export class SwitchHandler {
 
   setModeAwayExtendedSwitch(value: boolean): number | null {
     if (!value) {
-      return HK_NOT_ALLOWED_IN_CURRENT_STATE; 
+      return HK_NOT_ALLOWED_IN_CURRENT_STATE;
     }
     const delay = this.stateHandler.getArmingSeconds(SecurityState.AWAY);
     this.stateHandler.updateTargetState(SecurityState.AWAY, OriginType.INTERNAL, delay);
@@ -109,21 +116,6 @@ export class SwitchHandler {
 
     this.services[key].getCharacteristic(this.Characteristic.On).updateValue(value);
     return true;
-  }
-
-  isArmingLocked(targetState: SecurityState): boolean {
-    if (this.services.armingLockSwitchService.getCharacteristic(this.Characteristic.On).value) {
-      return true;
-    }
-
-    const modeMap: Record<number, keyof ServiceRegistry> = {
-      [SecurityState.HOME]: 'armingLockHomeSwitchService',
-      [SecurityState.AWAY]: 'armingLockAwaySwitchService',
-      [SecurityState.NIGHT]: 'armingLockNightSwitchService',
-    };
-
-    const svcKey = modeMap[targetState];
-    return svcKey ? Boolean(this.services[svcKey].getCharacteristic(this.Characteristic.On).value) : false;
   }
 
   // ── Mode switch display ────────────────────────────────────────────────────

--- a/src/handlers/switch-handler.ts
+++ b/src/handlers/switch-handler.ts
@@ -8,6 +8,7 @@ import type { SecuritySystemOptions } from '../interfaces/options-interface.js';
 import type { StateHandler } from './state-handler.js';
 import { OriginType } from '../types/origin-type.js';
 import { capitalise } from '../utils/state-util.js';
+import type { TimerManager } from '../timers/timer-manager.js';
 
 /** Handles all mode switches, arming-lock switches, and the pause/extended switches. */
 export class SwitchHandler {
@@ -19,6 +20,7 @@ export class SwitchHandler {
     private readonly options: SecuritySystemOptions,
     private readonly Characteristic: CharacteristicConstructor,
     private readonly log: Logging,
+    private readonly timers: TimerManager,
   ) {}
 
   setStateHandler(handler: StateHandler): void {
@@ -70,19 +72,15 @@ export class SwitchHandler {
       this.stateHandler.updateTargetState(SecurityState.OFF, OriginType.INTERNAL, 0);
 
       if (this.options.pauseMinutes !== 0) {
-        this.state.pauseTimeout = setTimeout(() => {
+        this.timers.setPauseTimer(this.options.pauseMinutes * 60 * 1000, () => {
           this.log.info('Mode pause (Finished)');
           const prev = this.state.pausedCurrentState ?? this.state.defaultState;
           this.stateHandler.updateTargetState(prev, OriginType.INTERNAL, this.stateHandler.getArmingSeconds(prev));
-        }, this.options.pauseMinutes * 60 * 1000);
+        });
       }
     } else {
       this.log.info('Mode pause (Cancelled)');
-
-      if (this.state.pauseTimeout !== null) {
-        clearTimeout(this.state.pauseTimeout);
-        this.state.pauseTimeout = null;
-      }
+      this.timers.clearPauseTimer();
 
       const prev = this.state.pausedCurrentState ?? this.state.defaultState;
       this.stateHandler.updateTargetState(prev, OriginType.INTERNAL, this.stateHandler.getArmingSeconds(prev));

--- a/src/handlers/trip-handler.ts
+++ b/src/handlers/trip-handler.ts
@@ -12,6 +12,7 @@ import type { AudioService } from '../services/audio-service.js';
 import type { SensorHandler } from './sensor-handler.js';
 import type { StateHandler } from './state-handler.js';
 import type { Condition } from '../conditions/condition.js';
+import type { TimerManager } from '../timers/timer-manager.js';
 import type { ConditionContext } from '../interfaces/condition-context-interface.js';
 import { NotArmedCondition } from '../conditions/not-armed-condition.js';
 import { ArmingInProgressCondition } from '../conditions/arming-in-progress-condition.js';
@@ -34,12 +35,16 @@ export class TripHandler {
     private readonly bus: EventBusService,
     private readonly audio: AudioService,
     private readonly sensorHandler: SensorHandler,
+    private readonly timers: TimerManager,
   ) {
-    const doubleKnock = new DoubleKnockCondition((seconds, onExpire) => {
-      this.state.doubleKnockTimeout = setTimeout(() => {
-        onExpire();
-      }, seconds * 1000);
-    });
+    const doubleKnock = new DoubleKnockCondition(
+      (seconds, onExpire) => {
+        this.timers.setDoubleKnockTimer(seconds * 1000, onExpire);
+      },
+      () => {
+        this.timers.clearDoubleKnockTimer();
+      },
+    );
 
     this.conditions = [
       new NotArmedCondition(),
@@ -130,19 +135,20 @@ export class TripHandler {
 
     if (this.options.trippedMotionSensor) {
       this.sensorHandler.pulseTrippedMotionSensor();
-      this.state.trippedMotionSensorInterval = setInterval(
-        () => this.sensorHandler.pulseTrippedMotionSensor(),
+      this.timers.setTrippedInterval(
         this.options.trippedMotionSensorSeconds * 1000,
+        () => this.sensorHandler.pulseTrippedMotionSensor(),
       );
     }
 
     const triggerSeconds = this.resolveTriggerSeconds();
     this.log.debug(`Trigger delay (${triggerSeconds}s)`);
 
-    this.state.triggerTimeout = setTimeout(() => {
-      this.state.triggerTimeout = null;
+    this.state.isTripping = true;
+    this.timers.setTriggerTimer(triggerSeconds * 1000, () => {
+      this.state.isTripping = false;
       this.stateHandler.setCurrentState(SecurityState.TRIGGERED, origin);
-    }, triggerSeconds * 1000);
+    });
 
     if (triggerSeconds > 0) {
       this.bus.emit(EventType.WARNING, { origin, triggerSeconds });
@@ -151,6 +157,7 @@ export class TripHandler {
 
   private cancelTrip(origin: OriginType, stateChanged: boolean): void {
     this.log.info('Security System (Cancelled)');
+    this.state.isTripping = false;
     this.audio.stop();
 
     if (this.state.currentState === SecurityState.TRIGGERED) {

--- a/src/handlers/trip-handler.ts
+++ b/src/handlers/trip-handler.ts
@@ -2,7 +2,6 @@ import type { Logging } from 'homebridge';
 import type { CharacteristicConstructor } from '../interfaces/hap-types-interface.js';
 import { SecurityState } from '../types/security-state-type.js';
 import { OriginType } from '../types/origin-type.js';
-import { HK_NOT_ALLOWED_IN_CURRENT_STATE } from '../constants/homekit-constant.js';
 import type { ServiceRegistry } from '../interfaces/service-registry-interface.js';
 import type { SystemState } from '../interfaces/system-state-interface.js';
 import type { SecuritySystemOptions } from '../interfaces/options-interface.js';
@@ -10,20 +9,21 @@ import type { EventBusService } from '../services/event-bus-service.js';
 import { EventType } from '../types/event-type.js';
 import type { AudioService } from '../services/audio-service.js';
 import type { SensorHandler } from './sensor-handler.js';
-import type { StateHandler } from './state-handler.js';
 import type { Condition } from '../conditions/condition.js';
-import type { TimerManager } from '../timers/timer-manager.js';
 import type { ConditionContext } from '../interfaces/condition-context-interface.js';
 import { NotArmedCondition } from '../conditions/not-armed-condition.js';
 import { ArmingInProgressCondition } from '../conditions/arming-in-progress-condition.js';
 import { AlreadyTriggeredCondition } from '../conditions/already-triggered-condition.js';
 import { DoubleKnockCondition } from '../conditions/double-knock-condition.js';
 import { TriggerAlreadyRunningCondition } from '../conditions/trigger-already-running-condition.js';
+import type { TimerManager } from '../timers/timer-manager.js';
 
-/** Handles the trip switch and trigger-delay logic, including all blocking conditions. */
+/**
+ * Handles the trip switch and trigger-delay logic, including all blocking conditions.
+ * Communicates state transitions back to the state machine via the event bus so that
+ * no circular import is needed with StateHandler.
+ */
 export class TripHandler {
-  private stateHandler!: StateHandler;
-
   private readonly conditions: readonly Condition[];
 
   constructor(
@@ -53,10 +53,6 @@ export class TripHandler {
       new AlreadyTriggeredCondition(),
       new TriggerAlreadyRunningCondition(),
     ];
-  }
-
-  setStateHandler(handler: StateHandler): void {
-    this.stateHandler = handler;
   }
 
   /**
@@ -147,7 +143,7 @@ export class TripHandler {
     this.state.isTripping = true;
     this.timers.setTriggerTimer(triggerSeconds * 1000, () => {
       this.state.isTripping = false;
-      this.stateHandler.setCurrentState(SecurityState.TRIGGERED, origin);
+      this.bus.emit(EventType.TRIGGER_FIRED, { origin });
     });
 
     if (triggerSeconds > 0) {
@@ -160,13 +156,7 @@ export class TripHandler {
     this.state.isTripping = false;
     this.audio.stop();
 
-    if (this.state.currentState === SecurityState.TRIGGERED) {
-      if (!stateChanged) {
-        this.stateHandler.updateTargetState(SecurityState.OFF, OriginType.INTERNAL, 0);
-      }
-    } else {
-      this.stateHandler.resetTimers();
-    }
+    this.bus.emit(EventType.TRIP_CANCELLED, { origin, stateChanged });
 
     if (this.options.trippedMotionSensor) {
       this.sensorHandler.resetTrippedMotionSensor();
@@ -203,5 +193,3 @@ export class TripHandler {
     return seconds;
   }
 }
-
-export { HK_NOT_ALLOWED_IN_CURRENT_STATE };

--- a/src/homekit/homekit-registrar.ts
+++ b/src/homekit/homekit-registrar.ts
@@ -1,0 +1,147 @@
+import type { API, Logging, CharacteristicValue } from 'homebridge';
+import { HAPStatus } from 'homebridge';
+import type { CharacteristicConstructor } from '../interfaces/hap-types-interface.js';
+import type { ServiceRegistry } from '../interfaces/service-registry-interface.js';
+import type { SystemState } from '../interfaces/system-state-interface.js';
+import { SecurityState } from '../types/security-state-type.js';
+import { OriginType } from '../types/origin-type.js';
+import { HK_NOT_ALLOWED_IN_CURRENT_STATE } from '../constants/homekit-constant.js';
+import type { StateHandler } from '../handlers/state-handler.js';
+import type { TripHandler } from '../handlers/trip-handler.js';
+import type { SwitchHandler } from '../handlers/switch-handler.js';
+
+/** Attaches all HomeKit characteristic handlers (onGet / onSet) to their services. */
+export class HomeKitRegistrar {
+  constructor(
+    private readonly api: API,
+    private readonly log: Logging,
+    private readonly svcs: ServiceRegistry,
+    private readonly state: SystemState,
+    private readonly stateHandler: StateHandler,
+    private readonly tripHandler: TripHandler,
+    private readonly switchHandler: SwitchHandler,
+  ) {}
+
+  register(Char: CharacteristicConstructor): void {
+    const s = this.svcs;
+    const HK_ERR = HK_NOT_ALLOWED_IN_CURRENT_STATE;
+
+    // Main security system.
+    s.mainService.getCharacteristic(Char.SecuritySystemCurrentState)
+      .onGet(async (): Promise<CharacteristicValue> => this.state.currentState);
+    s.mainService.getCharacteristic(Char.SecuritySystemTargetState)
+      .onGet(async (): Promise<CharacteristicValue> => this.state.targetState)
+      .onSet(async (v: CharacteristicValue) => {
+        this.stateHandler.updateTargetState(v as SecurityState, OriginType.REGULAR_SWITCH, this.stateHandler.getArmingSeconds(v as SecurityState));
+      });
+
+    // Trip switches.
+    const tripSetHandler = (v: CharacteristicValue, origin: OriginType) => {
+      const ok = this.tripHandler.updateTripSwitch(v as boolean, origin, false);
+      if (!ok) {
+        throw new this.api.hap.HapStatusError(HK_ERR as HAPStatus);
+      }
+    };
+
+    s.tripSwitchService.getCharacteristic(Char.On)
+      .onGet(async () => Boolean(s.tripSwitchService.getCharacteristic(Char.On).value))
+      .onSet(async (v: CharacteristicValue) => {
+        this.log.info(`Trip Switch (${v ? 'On' : 'Off'})`);
+        tripSetHandler(v, OriginType.REGULAR_SWITCH);
+      });
+
+    const modeTrips: Array<[keyof ServiceRegistry, SecurityState, string]> = [
+      ['tripHomeSwitchService', SecurityState.HOME, 'Trip Home'],
+      ['tripAwaySwitchService', SecurityState.AWAY, 'Trip Away'],
+      ['tripNightSwitchService', SecurityState.NIGHT, 'Trip Night'],
+    ];
+    for (const [key, mode, label] of modeTrips) {
+      const svc = s[key];
+      svc.getCharacteristic(Char.On)
+        .onGet(async () => Boolean(svc.getCharacteristic(Char.On).value))
+        .onSet(async (v: CharacteristicValue) => {
+          this.log.info(`${label} Switch (${v ? 'On' : 'Off'})`);
+          const ok = this.tripHandler.triggerIfModeSet(mode, v as boolean);
+          if (!ok) {
+            throw new this.api.hap.HapStatusError(HK_ERR as HAPStatus);
+          }
+        });
+    }
+
+    s.tripOverrideSwitchService.getCharacteristic(Char.On)
+      .onGet(async () => Boolean(s.tripOverrideSwitchService.getCharacteristic(Char.On).value))
+      .onSet(async (v: CharacteristicValue) => {
+        this.log.info(`Trip Override Switch (${v ? 'On' : 'Off'})`);
+        tripSetHandler(v, OriginType.OVERRIDE_SWITCH);
+      });
+
+    // Mode switches.
+    const modeSwitches: Array<[keyof ServiceRegistry, SecurityState | null, string]> = [
+      ['modeHomeSwitchService', SecurityState.HOME, 'Mode Home'],
+      ['modeAwaySwitchService', SecurityState.AWAY, 'Mode Away'],
+      ['modeNightSwitchService', SecurityState.NIGHT, 'Mode Night'],
+      ['modeOffSwitchService', null, 'Mode Off'],
+    ];
+    for (const [key, mode, label] of modeSwitches) {
+      const svc = s[key];
+      svc.getCharacteristic(Char.On)
+        .onGet(async () => Boolean(svc.getCharacteristic(Char.On).value))
+        .onSet(async (v: CharacteristicValue) => {
+          this.log.info(`${label} Switch (${v ? 'On' : 'Off'})`);
+          const err = mode !== null
+            ? this.switchHandler.setModeSwitch(mode, v as boolean)
+            : this.switchHandler.setModeOffSwitch(v as boolean);
+          if (err) {
+            throw new this.api.hap.HapStatusError(err as HAPStatus);
+          }
+        });
+    }
+
+    s.modeAwayExtendedSwitchService.getCharacteristic(Char.On)
+      .onGet(async () => Boolean(s.modeAwayExtendedSwitchService.getCharacteristic(Char.On).value))
+      .onSet(async (v: CharacteristicValue) => {
+        const err = this.switchHandler.setModeAwayExtendedSwitch(v as boolean);
+        if (err) {
+          throw new this.api.hap.HapStatusError(err as HAPStatus);
+        }
+      });
+
+    s.modePauseSwitchService.getCharacteristic(Char.On)
+      .onGet(async () => Boolean(s.modePauseSwitchService.getCharacteristic(Char.On).value))
+      .onSet(async (v: CharacteristicValue) => {
+        const err = this.switchHandler.setModePauseSwitch(v as boolean);
+        if (err) {
+          throw new this.api.hap.HapStatusError(err as HAPStatus);
+        }
+      });
+
+    // Arming lock switches.
+    const lockSwitches: Array<[keyof ServiceRegistry, string]> = [
+      ['armingLockSwitchService', 'global'],
+      ['armingLockHomeSwitchService', 'home'],
+      ['armingLockAwaySwitchService', 'away'],
+      ['armingLockNightSwitchService', 'night'],
+    ];
+    for (const [key, mode] of lockSwitches) {
+      const svc = s[key];
+      svc.getCharacteristic(Char.On)
+        .onGet(async () => Boolean(svc.getCharacteristic(Char.On).value))
+        .onSet(async (v: CharacteristicValue) => this.log.info(`Arming lock [${mode}] (${v ? 'On' : 'Off'})`));
+    }
+
+    // Audio switch.
+    s.audioSwitchService.getCharacteristic(Char.On)
+      .onGet(async () => Boolean(s.audioSwitchService.getCharacteristic(Char.On).value))
+      .onSet(async (v: CharacteristicValue) => this.log.info(`Audio (${v ? 'Enabled' : 'Disabled'})`));
+
+    // Motion sensors (read-only).
+    const sensorKeys = [
+      'armingMotionSensorService', 'trippedMotionSensorService',
+      'triggeredMotionSensorService', 'triggeredResetMotionSensorService',
+    ] as const;
+    for (const key of sensorKeys) {
+      s[key].getCharacteristic(Char.MotionDetected)
+        .onGet(async () => Boolean(s[key].getCharacteristic(Char.MotionDetected).value));
+    }
+  }
+}

--- a/src/homekit/service-factory.ts
+++ b/src/homekit/service-factory.ts
@@ -1,0 +1,139 @@
+import type { Service } from 'homebridge';
+import type { CharacteristicConstructor } from '../interfaces/hap-types-interface.js';
+import type { SecuritySystemOptions } from '../interfaces/options-interface.js';
+import type { ServiceRegistry } from '../interfaces/service-registry-interface.js';
+import type { SystemState } from '../interfaces/system-state-interface.js';
+import { SecurityState } from '../types/security-state-type.js';
+import { SWITCH_UUIDS } from '../constants/switch-uuid-constant.js';
+
+/** Creates the complete ServiceRegistry of HomeKit services for the accessory. */
+export function buildServiceRegistry(
+  Svc: typeof Service,
+  Char: CharacteristicConstructor,
+  options: SecuritySystemOptions,
+): ServiceRegistry {
+  const sw = (name: string, sub: string): Service => {
+    const s = new Svc.Switch(name, sub);
+    s.addCharacteristic(Char.ConfiguredName);
+    s.setCharacteristic(Char.ConfiguredName, name);
+    return s;
+  };
+  const sensor = (name: string, sub: string): Service => {
+    const s = new Svc.MotionSensor(name, sub);
+    s.addOptionalCharacteristic(Char.ConfiguredName);
+    s.setCharacteristic(Char.ConfiguredName, name);
+    return s;
+  };
+
+  const mainSvc = new Svc.SecuritySystem(options.name);
+  mainSvc.addCharacteristic(Char.ConfiguredName);
+
+  const infoSvc = new Svc.AccessoryInformation();
+  infoSvc.setCharacteristic(Char.Identify, true);
+  infoSvc.setCharacteristic(Char.Manufacturer, 'MiguelRipoll23');
+  infoSvc.setCharacteristic(Char.Model, 'DIY');
+  infoSvc.setCharacteristic(Char.SerialNumber, options.serialNumber);
+
+  const audioSvc = sw(options.audioSwitchName, SWITCH_UUIDS.AUDIO);
+  audioSvc.getCharacteristic(Char.On).value = true;
+
+  return {
+    mainService: mainSvc,
+    accessoryInfoService: infoSvc,
+    tripSwitchService: sw(options.tripSwitchName, SWITCH_UUIDS.TRIP),
+    tripHomeSwitchService: sw(options.tripHomeSwitchName, SWITCH_UUIDS.TRIP_HOME),
+    tripAwaySwitchService: sw(options.tripAwaySwitchName, SWITCH_UUIDS.TRIP_AWAY),
+    tripNightSwitchService: sw(options.tripNightSwitchName, SWITCH_UUIDS.TRIP_NIGHT),
+    tripOverrideSwitchService: sw(options.tripOverrideSwitchName, SWITCH_UUIDS.TRIP_OVERRIDE),
+    armingLockSwitchService: sw('Arming Lock', SWITCH_UUIDS.ARMING_LOCK),
+    armingLockHomeSwitchService: sw('Arming Lock Home', SWITCH_UUIDS.ARMING_LOCK_HOME),
+    armingLockAwaySwitchService: sw('Arming Lock Away', SWITCH_UUIDS.ARMING_LOCK_AWAY),
+    armingLockNightSwitchService: sw('Arming Lock Night', SWITCH_UUIDS.ARMING_LOCK_NIGHT),
+    modeHomeSwitchService: sw(options.modeHomeSwitchName, SWITCH_UUIDS.MODE_HOME),
+    modeAwaySwitchService: sw(options.modeAwaySwitchName, SWITCH_UUIDS.MODE_AWAY),
+    modeNightSwitchService: sw(options.modeNightSwitchName, SWITCH_UUIDS.MODE_NIGHT),
+    modeOffSwitchService: sw(options.modeOffSwitchName, SWITCH_UUIDS.MODE_OFF),
+    modeAwayExtendedSwitchService: sw(options.modeAwayExtendedSwitchName, SWITCH_UUIDS.MODE_AWAY_EXTENDED),
+    modePauseSwitchService: sw(options.modePauseSwitchName, SWITCH_UUIDS.MODE_PAUSE),
+    audioSwitchService: audioSvc,
+    armingMotionSensorService: sensor('Arming', SWITCH_UUIDS.ARMING_SENSOR),
+    trippedMotionSensorService: sensor('Tripped', SWITCH_UUIDS.TRIPPED_SENSOR),
+    triggeredMotionSensorService: sensor('Triggered', SWITCH_UUIDS.TRIGGERED_SENSOR),
+    triggeredResetMotionSensorService: sensor('Triggered Reset', SWITCH_UUIDS.RESET_SENSOR),
+  };
+}
+
+/** Builds the list of services to expose to HomeKit based on configured options. */
+export function buildServiceList(
+  svcs: ServiceRegistry,
+  options: SecuritySystemOptions,
+  state: Pick<SystemState, 'availableTargetStates'>,
+): Service[] {
+  const avail = state.availableTargetStates;
+  const list: Service[] = [svcs.mainService, svcs.accessoryInfoService];
+
+  if (options.armingMotionSensor) {
+    list.push(svcs.armingMotionSensorService);
+  }
+  if (options.trippedMotionSensor) {
+    list.push(svcs.trippedMotionSensorService);
+  }
+  if (options.triggeredMotionSensor) {
+    list.push(svcs.triggeredMotionSensorService);
+  }
+  if (options.resetSensor) {
+    list.push(svcs.triggeredResetMotionSensorService);
+  }
+  if (options.armingLockSwitch) {
+    list.push(svcs.armingLockSwitchService);
+  }
+  if (options.armingLockSwitches) {
+    list.push(svcs.armingLockHomeSwitchService, svcs.armingLockAwaySwitchService, svcs.armingLockNightSwitchService);
+  }
+  if (options.tripSwitch) {
+    list.push(svcs.tripSwitchService);
+  }
+  if (options.tripOverrideSwitch) {
+    list.push(svcs.tripOverrideSwitchService);
+  }
+
+  if (avail.includes(SecurityState.HOME)) {
+    if (options.modeSwitches) {
+      list.push(svcs.modeHomeSwitchService);
+    }
+    if (options.tripModeSwitches) {
+      list.push(svcs.tripHomeSwitchService);
+    }
+  }
+  if (avail.includes(SecurityState.AWAY)) {
+    if (options.modeSwitches) {
+      list.push(svcs.modeAwaySwitchService);
+    }
+    if (options.tripModeSwitches) {
+      list.push(svcs.tripAwaySwitchService);
+    }
+  }
+  if (avail.includes(SecurityState.NIGHT)) {
+    if (options.modeSwitches) {
+      list.push(svcs.modeNightSwitchService);
+    }
+    if (options.tripModeSwitches) {
+      list.push(svcs.tripNightSwitchService);
+    }
+  }
+
+  if (options.modeSwitches && options.modeOffSwitch) {
+    list.push(svcs.modeOffSwitchService);
+  }
+  if (options.modeAwayExtendedSwitch) {
+    list.push(svcs.modeAwayExtendedSwitchService);
+  }
+  if (options.modePauseSwitch) {
+    list.push(svcs.modePauseSwitchService);
+  }
+  if (options.audio && options.audioSwitch) {
+    list.push(svcs.audioSwitchService);
+  }
+
+  return list;
+}

--- a/src/interfaces/system-state-interface.ts
+++ b/src/interfaces/system-state-interface.ts
@@ -9,17 +9,9 @@ export interface SystemState {
   availableTargetStates: SecurityState[];
 
   isArming: boolean;
+  isTripping: boolean;
   isKnocked: boolean;
   invalidCodeCount: number;
   pausedCurrentState: SecurityState | null;
   audioProcess: ChildProcess | null;
-
-  // Active timers (null = not running)
-  armTimeout: ReturnType<typeof setTimeout> | null;
-  pauseTimeout: ReturnType<typeof setTimeout> | null;
-  triggerTimeout: ReturnType<typeof setTimeout> | null;
-  doubleKnockTimeout: ReturnType<typeof setTimeout> | null;
-  resetTimeout: ReturnType<typeof setTimeout> | null;
-  trippedMotionSensorInterval: ReturnType<typeof setInterval> | null;
-  triggeredMotionSensorInterval: ReturnType<typeof setInterval> | null;
 }

--- a/src/security-system.ts
+++ b/src/security-system.ts
@@ -19,6 +19,7 @@ import { SwitchHandler } from './handlers/switch-handler.js';
 import { SensorHandler } from './handlers/sensor-handler.js';
 import { buildServiceRegistry, buildServiceList } from './homekit/service-factory.js';
 import { HomeKitRegistrar } from './homekit/homekit-registrar.js';
+import { TimerManager } from './timers/timer-manager.js';
 
 export class SecuritySystem implements AccessoryPlugin {
   private readonly options: SecuritySystemOptions;
@@ -65,15 +66,16 @@ export class SecuritySystem implements AccessoryPlugin {
     this.audioService = new AudioService(log, this.options, this.state, () =>
       Boolean(this.svcs.audioSwitchService.getCharacteristic(Char.On).value),
     );
+    const timerManager = new TimerManager(log);
 
     // Handlers.
     this.sensorHandler = new SensorHandler(this.svcs, Char, log);
-    this.switchHandler = new SwitchHandler(this.svcs, this.state, this.options, Char, log);
+    this.switchHandler = new SwitchHandler(this.svcs, this.state, this.options, Char, log, timerManager);
     this.stateHandler = new StateHandler(
-      this.svcs, this.state, this.options, Char, log, this.bus, this.storageService, this.audioService,
+      this.svcs, this.state, this.options, Char, log, this.bus, this.storageService, this.audioService, timerManager,
     );
     this.tripHandler = new TripHandler(
-      this.svcs, this.state, this.options, Char, log, this.bus, this.audioService, this.sensorHandler,
+      this.svcs, this.state, this.options, Char, log, this.bus, this.audioService, this.sensorHandler, timerManager,
     );
 
     // Wire circular deps.
@@ -132,17 +134,11 @@ export class SecuritySystem implements AccessoryPlugin {
       defaultState,
       availableTargetStates: [],
       isArming: false,
+      isTripping: false,
       isKnocked: false,
       invalidCodeCount: 0,
       pausedCurrentState: null,
       audioProcess: null,
-      armTimeout: null,
-      pauseTimeout: null,
-      triggerTimeout: null,
-      doubleKnockTimeout: null,
-      resetTimeout: null,
-      trippedMotionSensorInterval: null,
-      triggeredMotionSensorInterval: null,
     };
   }
 

--- a/src/security-system.ts
+++ b/src/security-system.ts
@@ -7,7 +7,7 @@ import { HK_NOT_ALLOWED_IN_CURRENT_STATE } from './constants/homekit-constant.js
 import { SWITCH_UUIDS } from './constants/switch-uuid-constant.js';
 import { ConfigurationService } from './services/configuration-service.js';
 import { attachFileLogger } from './utils/log-util.js';
-import { stateToMode } from './utils/state-util.js';
+import { stateToMode, modeToState } from './utils/state-util.js';
 import type { SecuritySystemOptions } from './interfaces/options-interface.js';
 import type { SystemState } from './interfaces/system-state-interface.js';
 import type { ServiceRegistry } from './interfaces/service-registry-interface.js';
@@ -47,11 +47,11 @@ export class SecuritySystem implements AccessoryPlugin {
     this.options = new ConfigurationService(log, config).options;
     attachFileLogger(log, this.options);
 
-    const defaultState = this.modeToStateVal(this.options.defaultMode);
-    this.state = this.buildState(defaultState);
+    const defaultState = modeToState(this.options.defaultMode);
+    this.state = this.buildState(defaultState === (-1 as SecurityState) ? SecurityState.OFF : defaultState);
 
     this.svcs = this.buildServices(Svc, Char);
-    this.state.availableTargetStates = this.calcAvailableStates(Char);
+    this.state.availableTargetStates = this.calcAvailableTargetStates();
 
     // Sync main service initial values.
     this.svcs.mainService.getCharacteristic(Char.SecuritySystemTargetState).value = this.state.targetState;
@@ -387,31 +387,10 @@ export class SecuritySystem implements AccessoryPlugin {
     return list;
   }
 
-  private calcAvailableStates(Char: CharacteristicConstructor): SecurityState[] {
-    const all = this.svcs.mainService
-      .getCharacteristic(Char.SecuritySystemTargetState)
-      .props.validValues ?? [0, 1, 2, 3];
-
-    const disabled = this.options.disabledModes.map(m => {
-      switch (m.toLowerCase()) {
-      case 'home': return SecurityState.HOME;
-      case 'away': return SecurityState.AWAY;
-      case 'night': return SecurityState.NIGHT;
-      case 'off': return SecurityState.OFF;
-      default: return -1 as SecurityState;
-      }
-    });
-
-    return (all as SecurityState[]).filter(s => !disabled.includes(s));
-  }
-
-  private modeToStateVal(mode: string): SecurityState {
-    switch (mode) {
-    case 'home': return SecurityState.HOME;
-    case 'away': return SecurityState.AWAY;
-    case 'night': return SecurityState.NIGHT;
-    default: return SecurityState.OFF;
-    }
+  private calcAvailableTargetStates(): SecurityState[] {
+    const all = [SecurityState.HOME, SecurityState.AWAY, SecurityState.NIGHT, SecurityState.OFF];
+    const disabled = this.options.disabledModes.map(m => modeToState(m.toLowerCase()));
+    return all.filter(s => !disabled.includes(s));
   }
 
   private logStartup(): void {

--- a/src/security-system.ts
+++ b/src/security-system.ts
@@ -1,10 +1,6 @@
-import type { API, AccessoryPlugin, Logging, Service, CharacteristicValue } from 'homebridge';
-import { HAPStatus } from 'homebridge';
+import type { API, AccessoryPlugin, Logging, Service } from 'homebridge';
 import type { CharacteristicConstructor } from './interfaces/hap-types-interface.js';
 import { SecurityState } from './types/security-state-type.js';
-import { OriginType } from './types/origin-type.js';
-import { HK_NOT_ALLOWED_IN_CURRENT_STATE } from './constants/homekit-constant.js';
-import { SWITCH_UUIDS } from './constants/switch-uuid-constant.js';
 import { ConfigurationService } from './services/configuration-service.js';
 import { attachFileLogger } from './utils/log-util.js';
 import { stateToMode, modeToState } from './utils/state-util.js';
@@ -21,6 +17,8 @@ import { StateHandler } from './handlers/state-handler.js';
 import { TripHandler } from './handlers/trip-handler.js';
 import { SwitchHandler } from './handlers/switch-handler.js';
 import { SensorHandler } from './handlers/sensor-handler.js';
+import { buildServiceRegistry, buildServiceList } from './homekit/service-factory.js';
+import { HomeKitRegistrar } from './homekit/homekit-registrar.js';
 
 export class SecuritySystem implements AccessoryPlugin {
   private readonly options: SecuritySystemOptions;
@@ -50,7 +48,7 @@ export class SecuritySystem implements AccessoryPlugin {
     const defaultState = modeToState(this.options.defaultMode);
     this.state = this.buildState(defaultState === (-1 as SecurityState) ? SecurityState.OFF : defaultState);
 
-    this.svcs = this.buildServices(Svc, Char);
+    this.svcs = buildServiceRegistry(Svc, Char, this.options);
     this.state.availableTargetStates = this.calcAvailableTargetStates();
 
     // Sync main service initial values.
@@ -67,6 +65,8 @@ export class SecuritySystem implements AccessoryPlugin {
     this.audioService = new AudioService(log, this.options, this.state, () =>
       Boolean(this.svcs.audioSwitchService.getCharacteristic(Char.On).value),
     );
+
+    // Handlers.
     this.sensorHandler = new SensorHandler(this.svcs, Char, log);
     this.switchHandler = new SwitchHandler(this.svcs, this.state, this.options, Char, log);
     this.stateHandler = new StateHandler(
@@ -88,11 +88,12 @@ export class SecuritySystem implements AccessoryPlugin {
     webhookSvc.attachToBus(this.bus);
     commandSvc.attachToBus(this.bus);
 
-    // Register HomeKit handlers.
-    this.registerHandlers(Char);
+    // Register HomeKit characteristic handlers.
+    new HomeKitRegistrar(this.api, this.log, this.svcs, this.state, this.stateHandler, this.tripHandler, this.switchHandler)
+      .register(Char);
 
     // Build the exposed service list.
-    this.serviceList = this.buildServiceList();
+    this.serviceList = buildServiceList(this.svcs, this.options, this.state);
 
     // Startup tasks.
     this.logStartup();
@@ -145,248 +146,6 @@ export class SecuritySystem implements AccessoryPlugin {
     };
   }
 
-  private buildServices(Svc: typeof Service, Char: CharacteristicConstructor): ServiceRegistry {
-    const sw = (name: string, sub: string) => {
-      const s = new Svc.Switch(name, sub);
-      s.addCharacteristic(Char.ConfiguredName);
-      s.setCharacteristic(Char.ConfiguredName, name);
-      return s;
-    };
-    const sensor = (name: string, sub: string) => {
-      const s = new Svc.MotionSensor(name, sub);
-      s.addOptionalCharacteristic(Char.ConfiguredName);
-      s.setCharacteristic(Char.ConfiguredName, name);
-      return s;
-    };
-    const o = this.options;
-
-    const mainSvc = new Svc.SecuritySystem(o.name);
-    mainSvc.addCharacteristic(Char.ConfiguredName);
-
-    const infoSvc = new Svc.AccessoryInformation();
-    infoSvc.setCharacteristic(Char.Identify, true);
-    infoSvc.setCharacteristic(Char.Manufacturer, 'MiguelRipoll23');
-    infoSvc.setCharacteristic(Char.Model, 'DIY');
-    infoSvc.setCharacteristic(Char.SerialNumber, o.serialNumber);
-
-    const audioSvc = sw(o.audioSwitchName, SWITCH_UUIDS.AUDIO);
-    audioSvc.getCharacteristic(Char.On).value = true;
-
-    return {
-      mainService: mainSvc,
-      accessoryInfoService: infoSvc,
-      tripSwitchService: sw(o.tripSwitchName, SWITCH_UUIDS.TRIP),
-      tripHomeSwitchService: sw(o.tripHomeSwitchName, SWITCH_UUIDS.TRIP_HOME),
-      tripAwaySwitchService: sw(o.tripAwaySwitchName, SWITCH_UUIDS.TRIP_AWAY),
-      tripNightSwitchService: sw(o.tripNightSwitchName, SWITCH_UUIDS.TRIP_NIGHT),
-      tripOverrideSwitchService: sw(o.tripOverrideSwitchName, SWITCH_UUIDS.TRIP_OVERRIDE),
-      armingLockSwitchService: sw('Arming Lock', SWITCH_UUIDS.ARMING_LOCK),
-      armingLockHomeSwitchService: sw('Arming Lock Home', SWITCH_UUIDS.ARMING_LOCK_HOME),
-      armingLockAwaySwitchService: sw('Arming Lock Away', SWITCH_UUIDS.ARMING_LOCK_AWAY),
-      armingLockNightSwitchService: sw('Arming Lock Night', SWITCH_UUIDS.ARMING_LOCK_NIGHT),
-      modeHomeSwitchService: sw(o.modeHomeSwitchName, SWITCH_UUIDS.MODE_HOME),
-      modeAwaySwitchService: sw(o.modeAwaySwitchName, SWITCH_UUIDS.MODE_AWAY),
-      modeNightSwitchService: sw(o.modeNightSwitchName, SWITCH_UUIDS.MODE_NIGHT),
-      modeOffSwitchService: sw(o.modeOffSwitchName, SWITCH_UUIDS.MODE_OFF),
-      modeAwayExtendedSwitchService: sw(o.modeAwayExtendedSwitchName, SWITCH_UUIDS.MODE_AWAY_EXTENDED),
-      modePauseSwitchService: sw(o.modePauseSwitchName, SWITCH_UUIDS.MODE_PAUSE),
-      audioSwitchService: audioSvc,
-      armingMotionSensorService: sensor('Arming', SWITCH_UUIDS.ARMING_SENSOR),
-      trippedMotionSensorService: sensor('Tripped', SWITCH_UUIDS.TRIPPED_SENSOR),
-      triggeredMotionSensorService: sensor('Triggered', SWITCH_UUIDS.TRIGGERED_SENSOR),
-      triggeredResetMotionSensorService: sensor('Triggered Reset', SWITCH_UUIDS.RESET_SENSOR),
-    };
-  }
-
-  private registerHandlers(Char: CharacteristicConstructor): void {
-    const s = this.svcs;
-    const HK_ERR = HK_NOT_ALLOWED_IN_CURRENT_STATE;
-
-    // Main security system.
-    s.mainService.getCharacteristic(Char.SecuritySystemCurrentState)
-      .onGet(async (): Promise<CharacteristicValue> => this.state.currentState);
-    s.mainService.getCharacteristic(Char.SecuritySystemTargetState)
-      .onGet(async (): Promise<CharacteristicValue> => this.state.targetState)
-      .onSet(async (v: CharacteristicValue) => {
-        this.stateHandler.updateTargetState(v as SecurityState, OriginType.REGULAR_SWITCH, this.stateHandler.getArmingSeconds(v as SecurityState));
-      });
-
-    // Trip switches.
-    const tripSetHandler = (v: CharacteristicValue, origin: OriginType) => {
-      const ok = this.tripHandler.updateTripSwitch(v as boolean, origin, false);
-      if (!ok) {
-        throw new this.api.hap.HapStatusError(HK_ERR as HAPStatus); 
-      }
-    };
-
-    s.tripSwitchService.getCharacteristic(Char.On)
-      .onGet(async () => Boolean(s.tripSwitchService.getCharacteristic(Char.On).value))
-      .onSet(async (v) => {
-        this.log.info(`Trip Switch (${v ? 'On' : 'Off'})`); tripSetHandler(v, OriginType.REGULAR_SWITCH); 
-      });
-
-    const modeTrips: Array<[keyof ServiceRegistry, SecurityState, string]> = [
-      ['tripHomeSwitchService', SecurityState.HOME, 'Trip Home'],
-      ['tripAwaySwitchService', SecurityState.AWAY, 'Trip Away'],
-      ['tripNightSwitchService', SecurityState.NIGHT, 'Trip Night'],
-    ];
-    for (const [key, mode, label] of modeTrips) {
-      const svc = s[key];
-      svc.getCharacteristic(Char.On)
-        .onGet(async () => Boolean(svc.getCharacteristic(Char.On).value))
-        .onSet(async (v) => {
-          this.log.info(`${label} Switch (${v ? 'On' : 'Off'})`);
-          const ok = this.tripHandler.triggerIfModeSet(mode, v as boolean);
-          if (!ok) {
-            throw new this.api.hap.HapStatusError(HK_ERR as HAPStatus); 
-          }
-        });
-    }
-
-    s.tripOverrideSwitchService.getCharacteristic(Char.On)
-      .onGet(async () => Boolean(s.tripOverrideSwitchService.getCharacteristic(Char.On).value))
-      .onSet(async (v) => {
-        this.log.info(`Trip Override Switch (${v ? 'On' : 'Off'})`); tripSetHandler(v, OriginType.OVERRIDE_SWITCH); 
-      });
-
-    // Mode switches.
-    const modeSwitches: Array<[keyof ServiceRegistry, SecurityState | null, string]> = [
-      ['modeHomeSwitchService', SecurityState.HOME, 'Mode Home'],
-      ['modeAwaySwitchService', SecurityState.AWAY, 'Mode Away'],
-      ['modeNightSwitchService', SecurityState.NIGHT, 'Mode Night'],
-      ['modeOffSwitchService', null, 'Mode Off'],
-    ];
-    for (const [key, mode, label] of modeSwitches) {
-      const svc = s[key];
-      svc.getCharacteristic(Char.On)
-        .onGet(async () => Boolean(svc.getCharacteristic(Char.On).value))
-        .onSet(async (v) => {
-          this.log.info(`${label} Switch (${v ? 'On' : 'Off'})`);
-          const err = mode !== null ? this.switchHandler.setModeSwitch(mode, v as boolean) : this.switchHandler.setModeOffSwitch(v as boolean);
-          if (err) {
-            throw new this.api.hap.HapStatusError(err as HAPStatus); 
-          }
-        });
-    }
-
-    s.modeAwayExtendedSwitchService.getCharacteristic(Char.On)
-      .onGet(async () => Boolean(s.modeAwayExtendedSwitchService.getCharacteristic(Char.On).value))
-      .onSet(async (v) => {
-        const err = this.switchHandler.setModeAwayExtendedSwitch(v as boolean);
-        if (err) {
-          throw new this.api.hap.HapStatusError(err as HAPStatus); 
-        }
-      });
-
-    s.modePauseSwitchService.getCharacteristic(Char.On)
-      .onGet(async () => Boolean(s.modePauseSwitchService.getCharacteristic(Char.On).value))
-      .onSet(async (v) => {
-        const err = this.switchHandler.setModePauseSwitch(v as boolean);
-        if (err) {
-          throw new this.api.hap.HapStatusError(err as HAPStatus); 
-        }
-      });
-
-    // Arming lock switches.
-    const lockSwitches: Array<[keyof ServiceRegistry, string]> = [
-      ['armingLockSwitchService', 'global'],
-      ['armingLockHomeSwitchService', 'home'],
-      ['armingLockAwaySwitchService', 'away'],
-      ['armingLockNightSwitchService', 'night'],
-    ];
-    for (const [key, mode] of lockSwitches) {
-      const svc = s[key];
-      svc.getCharacteristic(Char.On)
-        .onGet(async () => Boolean(svc.getCharacteristic(Char.On).value))
-        .onSet(async (v) => this.log.info(`Arming lock [${mode}] (${v ? 'On' : 'Off'})`));
-    }
-
-    // Audio switch.
-    s.audioSwitchService.getCharacteristic(Char.On)
-      .onGet(async () => Boolean(s.audioSwitchService.getCharacteristic(Char.On).value))
-      .onSet(async (v) => this.log.info(`Audio (${v ? 'Enabled' : 'Disabled'})`));
-
-    // Motion sensors (read-only).
-    const sensorKeys = ['armingMotionSensorService', 'trippedMotionSensorService',
-      'triggeredMotionSensorService', 'triggeredResetMotionSensorService'] as const;
-    for (const key of sensorKeys) {
-      s[key].getCharacteristic(Char.MotionDetected)
-        .onGet(async () => Boolean(s[key].getCharacteristic(Char.MotionDetected).value));
-    }
-  }
-
-  private buildServiceList(): Service[] {
-    const s = this.svcs;
-    const o = this.options;
-    const avail = this.state.availableTargetStates;
-    const list: Service[] = [s.mainService, s.accessoryInfoService];
-
-    if (o.armingMotionSensor) {
-      list.push(s.armingMotionSensorService); 
-    }
-    if (o.trippedMotionSensor) {
-      list.push(s.trippedMotionSensorService); 
-    }
-    if (o.triggeredMotionSensor) {
-      list.push(s.triggeredMotionSensorService); 
-    }
-    if (o.resetSensor) {
-      list.push(s.triggeredResetMotionSensorService); 
-    }
-    if (o.armingLockSwitch) {
-      list.push(s.armingLockSwitchService); 
-    }
-    if (o.armingLockSwitches) {
-      list.push(s.armingLockHomeSwitchService, s.armingLockAwaySwitchService, s.armingLockNightSwitchService);
-    }
-    if (o.tripSwitch) {
-      list.push(s.tripSwitchService); 
-    }
-    if (o.tripOverrideSwitch) {
-      list.push(s.tripOverrideSwitchService); 
-    }
-
-    if (avail.includes(SecurityState.HOME)) {
-      if (o.modeSwitches) {
-        list.push(s.modeHomeSwitchService); 
-      }
-      if (o.tripModeSwitches) {
-        list.push(s.tripHomeSwitchService); 
-      }
-    }
-    if (avail.includes(SecurityState.AWAY)) {
-      if (o.modeSwitches) {
-        list.push(s.modeAwaySwitchService); 
-      }
-      if (o.tripModeSwitches) {
-        list.push(s.tripAwaySwitchService); 
-      }
-    }
-    if (avail.includes(SecurityState.NIGHT)) {
-      if (o.modeSwitches) {
-        list.push(s.modeNightSwitchService); 
-      }
-      if (o.tripModeSwitches) {
-        list.push(s.tripNightSwitchService); 
-      }
-    }
-
-    if (o.modeSwitches && o.modeOffSwitch) {
-      list.push(s.modeOffSwitchService); 
-    }
-    if (o.modeAwayExtendedSwitch) {
-      list.push(s.modeAwayExtendedSwitchService); 
-    }
-    if (o.modePauseSwitch) {
-      list.push(s.modePauseSwitchService); 
-    }
-    if (o.audio && o.audioSwitch) {
-      list.push(s.audioSwitchService); 
-    }
-
-    return list;
-  }
-
   private calcAvailableTargetStates(): SecurityState[] {
     const all = [SecurityState.HOME, SecurityState.AWAY, SecurityState.NIGHT, SecurityState.OFF];
     const disabled = this.options.disabledModes.map(m => modeToState(m.toLowerCase()));
@@ -395,7 +154,7 @@ export class SecuritySystem implements AccessoryPlugin {
 
   private logStartup(): void {
     if (this.options.testMode) {
-      this.log.warn('Test Mode'); 
+      this.log.warn('Test Mode');
     }
     stateToMode(this.state.defaultState);
     this.stateHandler.logMode('Default', this.state.defaultState);
@@ -403,10 +162,10 @@ export class SecuritySystem implements AccessoryPlugin {
     this.log.info(`Trigger delay (${this.options.triggerSeconds}s)`);
     this.log.info(`Audio (${this.options.audio ? 'Enabled' : 'Disabled'})`);
     if (this.options.proxyMode) {
-      this.log.info('Proxy mode (Enabled)'); 
+      this.log.info('Proxy mode (Enabled)');
     }
     if (this.options.webhookUrl) {
-      this.log.info(`Webhook (${this.options.webhookUrl})`); 
+      this.log.info(`Webhook (${this.options.webhookUrl})`);
     }
   }
 }

--- a/src/security-system.ts
+++ b/src/security-system.ts
@@ -1,6 +1,7 @@
 import type { API, AccessoryPlugin, Logging, Service } from 'homebridge';
 import type { CharacteristicConstructor } from './interfaces/hap-types-interface.js';
 import { SecurityState } from './types/security-state-type.js';
+import { OriginType } from './types/origin-type.js';
 import { ConfigurationService } from './services/configuration-service.js';
 import { attachFileLogger } from './utils/log-util.js';
 import { stateToMode, modeToState } from './utils/state-util.js';
@@ -8,6 +9,7 @@ import type { SecuritySystemOptions } from './interfaces/options-interface.js';
 import type { SystemState } from './interfaces/system-state-interface.js';
 import type { ServiceRegistry } from './interfaces/service-registry-interface.js';
 import { EventBusService } from './services/event-bus-service.js';
+import { EventType } from './types/event-type.js';
 import { StorageService } from './services/storage-service.js';
 import { AudioService } from './services/audio-service.js';
 import { WebhookService } from './services/webhook-service.js';
@@ -68,20 +70,30 @@ export class SecuritySystem implements AccessoryPlugin {
     );
     const timerManager = new TimerManager(log);
 
-    // Handlers.
+    // Handlers — construction order matters: sensorHandler first (leaf), then stateHandler,
+    // then switchHandler (depends on stateHandler), then tripHandler.
     this.sensorHandler = new SensorHandler(this.svcs, Char, log);
-    this.switchHandler = new SwitchHandler(this.svcs, this.state, this.options, Char, log, timerManager);
     this.stateHandler = new StateHandler(
-      this.svcs, this.state, this.options, Char, log, this.bus, this.storageService, this.audioService, timerManager,
+      this.svcs, this.state, this.options, Char, log, this.bus, this.storageService, this.audioService, timerManager, this.sensorHandler,
     );
+    this.switchHandler = new SwitchHandler(this.svcs, this.state, this.options, Char, log, timerManager, this.stateHandler);
     this.tripHandler = new TripHandler(
       this.svcs, this.state, this.options, Char, log, this.bus, this.audioService, this.sensorHandler, timerManager,
     );
 
-    // Wire circular deps.
-    this.stateHandler.setHandlers(this.tripHandler, this.switchHandler, this.sensorHandler);
-    this.switchHandler.setStateHandler(this.stateHandler);
-    this.tripHandler.setStateHandler(this.stateHandler);
+    // Wire bus listeners for cross-handler coordination (no more circular constructor deps).
+    this.switchHandler.subscribeToStateEvents(this.bus);
+    this.bus.on(EventType.RESET_TRIP_SWITCHES, () => this.tripHandler.resetTripSwitches());
+    this.bus.on(EventType.TRIGGER_FIRED, ({ origin }) => {
+      this.stateHandler.setCurrentState(SecurityState.TRIGGERED, origin);
+    });
+    this.bus.on(EventType.TRIP_CANCELLED, ({ stateChanged }) => {
+      if (this.state.currentState === SecurityState.TRIGGERED && !stateChanged) {
+        this.stateHandler.updateTargetState(SecurityState.OFF, OriginType.INTERNAL, 0);
+      } else {
+        this.stateHandler.resetTimers();
+      }
+    });
 
     // Attach side-effect listeners.
     this.audioService.attachToBus(this.bus);

--- a/src/services/server-service.ts
+++ b/src/services/server-service.ts
@@ -53,7 +53,7 @@ export class ServerService {
         arming: this.state.isArming,
         current_mode: stateToMode(this.state.currentState),
         target_mode: stateToMode(this.state.targetState),
-        tripped: this.state.triggerTimeout !== null,
+        tripped: this.stateHandler.isTripping(),
       });
     });
 

--- a/src/tests/conditions.test.ts
+++ b/src/tests/conditions.test.ts
@@ -18,17 +18,11 @@ function makeState(overrides: Partial<SystemState> = {}): SystemState {
     defaultState: SecurityState.OFF,
     availableTargetStates: [SecurityState.HOME, SecurityState.AWAY, SecurityState.NIGHT, SecurityState.OFF],
     isArming: false,
+    isTripping: false,
     isKnocked: false,
     invalidCodeCount: 0,
     pausedCurrentState: null,
     audioProcess: null,
-    armTimeout: null,
-    pauseTimeout: null,
-    triggerTimeout: null,
-    doubleKnockTimeout: null,
-    resetTimeout: null,
-    trippedMotionSensorInterval: null,
-    triggeredMotionSensorInterval: null,
     ...overrides,
   };
 }
@@ -139,7 +133,7 @@ describe('AlreadyTriggeredCondition', () => {
 describe('DoubleKnockCondition', () => {
   it('allows through when doubleKnock option is disabled', () => {
     const onFirstKnock = vi.fn();
-    const cond = new DoubleKnockCondition(onFirstKnock);
+    const cond = new DoubleKnockCondition(onFirstKnock, vi.fn());
     const state = makeState({ isKnocked: false });
     const opts = makeOptions({ doubleKnock: false, doubleKnockModes: ['home'] });
     expect(cond.evaluate(makeCtx(state, opts, true))).toBe(false);
@@ -148,7 +142,7 @@ describe('DoubleKnockCondition', () => {
 
   it('allows override switch to bypass double-knock', () => {
     const onFirstKnock = vi.fn();
-    const cond = new DoubleKnockCondition(onFirstKnock);
+    const cond = new DoubleKnockCondition(onFirstKnock, vi.fn());
     const state = makeState({ isKnocked: false, currentState: SecurityState.HOME });
     const opts = makeOptions({ doubleKnock: true, doubleKnockModes: ['home'], doubleKnockSeconds: 90 });
     expect(cond.evaluate(makeCtx(state, opts, true, OriginType.OVERRIDE_SWITCH))).toBe(false);
@@ -157,7 +151,7 @@ describe('DoubleKnockCondition', () => {
 
   it('blocks first knock and calls onFirstKnock', () => {
     const onFirstKnock = vi.fn();
-    const cond = new DoubleKnockCondition(onFirstKnock);
+    const cond = new DoubleKnockCondition(onFirstKnock, vi.fn());
     const state = makeState({ isKnocked: false, currentState: SecurityState.HOME });
     const opts = makeOptions({ doubleKnock: true, doubleKnockModes: ['home'], doubleKnockSeconds: 90 });
     expect(cond.evaluate(makeCtx(state, opts, true))).toBe(true);
@@ -166,7 +160,7 @@ describe('DoubleKnockCondition', () => {
   });
 
   it('allows second knock through and clears isKnocked', () => {
-    const cond = new DoubleKnockCondition(vi.fn());
+    const cond = new DoubleKnockCondition(vi.fn(), vi.fn());
     const state = makeState({ isKnocked: true, currentState: SecurityState.HOME });
     const opts = makeOptions({ doubleKnock: true, doubleKnockModes: ['home'], doubleKnockSeconds: 90 });
     expect(cond.evaluate(makeCtx(state, opts, true))).toBe(false);
@@ -175,7 +169,7 @@ describe('DoubleKnockCondition', () => {
 
   it('uses mode-specific knock window when configured', () => {
     const onFirstKnock = vi.fn();
-    const cond = new DoubleKnockCondition(onFirstKnock);
+    const cond = new DoubleKnockCondition(onFirstKnock, vi.fn());
     const state = makeState({ isKnocked: false, currentState: SecurityState.AWAY });
     const opts = makeOptions({ doubleKnock: true, doubleKnockModes: ['away'], doubleKnockSeconds: 90, awayDoubleKnockSeconds: 30 });
     cond.evaluate(makeCtx(state, opts, true));

--- a/src/tests/state-handler.test.ts
+++ b/src/tests/state-handler.test.ts
@@ -140,7 +140,9 @@ describe('StateHandler.getArmingSeconds', async () => {
     const bus = new EventBusService();
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    stateHandler = new StateHandler(services, state, options, {} as any, log as any, bus, makeStorage(), makeAudio(), makeTimers());
+    const sensor = makeMockSensor() as any;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    stateHandler = new StateHandler(services, state, options, {} as any, log as any, bus, makeStorage(), makeAudio(), makeTimers(), sensor);
   });
 
   it('returns 0 when current state is TRIGGERED', () => {
@@ -170,15 +172,9 @@ describe('StateHandler.updateTargetState', async () => {
     const log = makeMockLog();
     const bus = new EventBusService();
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const handler = new StateHandler(makeServices(), state, makeOptions(), {} as any, log as any, bus, makeStorage(), makeAudio(), makeTimers());
-    const mockTrip = { resetTripSwitches: vi.fn() };
-    const mockSw = {
-      resetModeSwitches: vi.fn(),
-      updateModeSwitches: vi.fn(),
-      isArmingLocked: vi.fn().mockReturnValue(false),
-    };
+    const sensor = makeMockSensor() as any;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    handler.setHandlers(mockTrip as any, mockSw as any, makeMockSensor() as any);
+    const handler = new StateHandler(makeServices(), state, makeOptions(), {} as any, log as any, bus, makeStorage(), makeAudio(), makeTimers(), sensor);
 
     const result = handler.updateTargetState(SecurityState.HOME, OriginType.INTERNAL, 0);
     expect(result).toBe(false);
@@ -190,15 +186,9 @@ describe('StateHandler.updateTargetState', async () => {
     const log = makeMockLog();
     const bus = new EventBusService();
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const handler = new StateHandler(makeServices(), state, makeOptions(), {} as any, log as any, bus, makeStorage(), makeAudio(), makeTimers());
-    const mockTrip = { resetTripSwitches: vi.fn() };
-    const mockSw = {
-      resetModeSwitches: vi.fn(),
-      updateModeSwitches: vi.fn(),
-      isArmingLocked: vi.fn().mockReturnValue(false),
-    };
+    const sensor = makeMockSensor() as any;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    handler.setHandlers(mockTrip as any, mockSw as any, makeMockSensor() as any);
+    const handler = new StateHandler(makeServices(), state, makeOptions(), {} as any, log as any, bus, makeStorage(), makeAudio(), makeTimers(), sensor);
 
     const result = handler.updateTargetState(SecurityState.HOME, OriginType.REGULAR_SWITCH, 0);
     // armSeconds=0 → synchronous transition; function returns false after setCurrentState

--- a/src/tests/state-handler.test.ts
+++ b/src/tests/state-handler.test.ts
@@ -52,17 +52,11 @@ function makeState(overrides: Partial<SystemState> = {}): SystemState {
     defaultState: SecurityState.OFF,
     availableTargetStates: [SecurityState.HOME, SecurityState.AWAY, SecurityState.NIGHT, SecurityState.OFF],
     isArming: false,
+    isTripping: false,
     isKnocked: false,
     invalidCodeCount: 0,
     pausedCurrentState: null,
     audioProcess: null,
-    armTimeout: null,
-    pauseTimeout: null,
-    triggerTimeout: null,
-    doubleKnockTimeout: null,
-    resetTimeout: null,
-    trippedMotionSensorInterval: null,
-    triggeredMotionSensorInterval: null,
     ...overrides,
   };
 }
@@ -105,6 +99,20 @@ function makeAudio() {
   return { play: vi.fn(), stop: vi.fn(), attachToBus: vi.fn() } as unknown as AudioService;
 }
 
+function makeTimers() {
+  return {
+    setArmTimer: vi.fn(), clearArmTimer: vi.fn(),
+    setTriggerTimer: vi.fn(), clearTriggerTimer: vi.fn(), isTriggerRunning: vi.fn().mockReturnValue(false),
+    setPauseTimer: vi.fn(), clearPauseTimer: vi.fn(),
+    setDoubleKnockTimer: vi.fn(), clearDoubleKnockTimer: vi.fn(),
+    setResetTimer: vi.fn(), clearResetTimer: vi.fn(),
+    setTrippedInterval: vi.fn(), clearTrippedInterval: vi.fn(),
+    setTriggeredInterval: vi.fn(), clearTriggeredInterval: vi.fn(),
+    clearAll: vi.fn(),
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any;
+}
+
 function makeMockSensor() {
   return {
     resetArmingMotionSensor: vi.fn(),
@@ -132,7 +140,7 @@ describe('StateHandler.getArmingSeconds', async () => {
     const bus = new EventBusService();
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    stateHandler = new StateHandler(services, state, options, {} as any, log as any, bus, makeStorage(), makeAudio());
+    stateHandler = new StateHandler(services, state, options, {} as any, log as any, bus, makeStorage(), makeAudio(), makeTimers());
   });
 
   it('returns 0 when current state is TRIGGERED', () => {
@@ -162,7 +170,7 @@ describe('StateHandler.updateTargetState', async () => {
     const log = makeMockLog();
     const bus = new EventBusService();
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const handler = new StateHandler(makeServices(), state, makeOptions(), {} as any, log as any, bus, makeStorage(), makeAudio());
+    const handler = new StateHandler(makeServices(), state, makeOptions(), {} as any, log as any, bus, makeStorage(), makeAudio(), makeTimers());
     const mockTrip = { resetTripSwitches: vi.fn() };
     const mockSw = {
       resetModeSwitches: vi.fn(),
@@ -182,7 +190,7 @@ describe('StateHandler.updateTargetState', async () => {
     const log = makeMockLog();
     const bus = new EventBusService();
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const handler = new StateHandler(makeServices(), state, makeOptions(), {} as any, log as any, bus, makeStorage(), makeAudio());
+    const handler = new StateHandler(makeServices(), state, makeOptions(), {} as any, log as any, bus, makeStorage(), makeAudio(), makeTimers());
     const mockTrip = { resetTripSwitches: vi.fn() };
     const mockSw = {
       resetModeSwitches: vi.fn(),

--- a/src/tests/trip-handler.test.ts
+++ b/src/tests/trip-handler.test.ts
@@ -50,17 +50,11 @@ function makeState(overrides: Partial<SystemState> = {}): SystemState {
     defaultState: SecurityState.OFF,
     availableTargetStates: [SecurityState.HOME, SecurityState.AWAY, SecurityState.NIGHT, SecurityState.OFF],
     isArming: false,
+    isTripping: false,
     isKnocked: false,
     invalidCodeCount: 0,
     pausedCurrentState: null,
     audioProcess: null,
-    armTimeout: null,
-    pauseTimeout: null,
-    triggerTimeout: null,
-    doubleKnockTimeout: null,
-    resetTimeout: null,
-    trippedMotionSensorInterval: null,
-    triggeredMotionSensorInterval: null,
     ...overrides,
   };
 }
@@ -106,6 +100,13 @@ describe('TripHandler', async () => {
     resetTrippedMotionSensor: vi.fn(),
   };
   const mockAudio = { stop: vi.fn(), play: vi.fn(), attachToBus: vi.fn() };
+  const mockTimers = {
+    setTriggerTimer: vi.fn(), clearTriggerTimer: vi.fn(), isTriggerRunning: vi.fn().mockReturnValue(false),
+    setTrippedInterval: vi.fn(), clearTrippedInterval: vi.fn(),
+    setDoubleKnockTimer: vi.fn(), clearDoubleKnockTimer: vi.fn(),
+    clearAll: vi.fn(),
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any;
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -114,7 +115,7 @@ describe('TripHandler', async () => {
     const bus = new EventBusService();
     const mockLog = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() };
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    tripHandler = new TripHandler(services, state, makeOptions(), {} as any, mockLog as any, bus, mockAudio as any, mockSensorHandler as any);
+    tripHandler = new TripHandler(services, state, makeOptions(), {} as any, mockLog as any, bus, mockAudio as any, mockSensorHandler as any, mockTimers);
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     tripHandler.setStateHandler(mockStateHandler as any);
   });
@@ -138,10 +139,10 @@ describe('TripHandler', async () => {
   });
 
   it('blocks trip when trigger timeout is already running', () => {
-    state.triggerTimeout = setTimeout(() => {}, 99999);
+    state.isTripping = true;
     const result = tripHandler.updateTripSwitch(true, OriginType.REGULAR_SWITCH, false);
     expect(result).toBe(false);
-    clearTimeout(state.triggerTimeout!);
+    state.isTripping = false;
   });
 
   it('allows trip when system is armed (HOME mode)', () => {

--- a/src/tests/trip-handler.test.ts
+++ b/src/tests/trip-handler.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { SecurityState } from '../types/security-state-type.js';
 import { OriginType } from '../types/origin-type.js';
+import { EventType } from '../types/event-type.js';
 import type { SystemState } from '../interfaces/system-state-interface.js';
 import type { SecuritySystemOptions } from '../interfaces/options-interface.js';
 import type { ServiceRegistry } from '../interfaces/service-registry-interface.js';
@@ -10,7 +11,7 @@ import type { ServiceRegistry } from '../interfaces/service-registry-interface.j
 function makeMockChar(value: unknown = false) {
   const c = { value, updateValue: vi.fn() };
   c.updateValue.mockImplementation((v: unknown) => {
-    c.value = v; 
+    c.value = v;
   });
   return c;
 }
@@ -38,7 +39,7 @@ function makeServices(): ServiceRegistry {
   ];
   const s: Record<string, ReturnType<typeof makeMockService>> = {};
   for (const k of keys) {
-    s[k] = makeMockService(); 
+    s[k] = makeMockService();
   }
   return s as unknown as ServiceRegistry;
 }
@@ -87,14 +88,9 @@ describe('TripHandler', async () => {
 
   let state: SystemState;
   let services: ServiceRegistry;
+  let bus: InstanceType<typeof EventBusService>;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   let tripHandler: any;
-  const mockStateHandler = {
-    setCurrentState: vi.fn(),
-    updateTargetState: vi.fn(),
-    resetTimers: vi.fn(),
-    getArmingSeconds: vi.fn().mockReturnValue(0),
-  };
   const mockSensorHandler = {
     pulseTrippedMotionSensor: vi.fn(),
     resetTrippedMotionSensor: vi.fn(),
@@ -112,12 +108,10 @@ describe('TripHandler', async () => {
     vi.clearAllMocks();
     state = makeState({ currentState: SecurityState.HOME });
     services = makeServices();
-    const bus = new EventBusService();
+    bus = new EventBusService();
     const mockLog = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() };
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     tripHandler = new TripHandler(services, state, makeOptions(), {} as any, mockLog as any, bus, mockAudio as any, mockSensorHandler as any, mockTimers);
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    tripHandler.setStateHandler(mockStateHandler as any);
   });
 
   it('blocks trip when system is disarmed (not overriding)', () => {
@@ -152,21 +146,41 @@ describe('TripHandler', async () => {
   });
 
   it('cancels trip and stops audio', () => {
+    const emitted: unknown[] = [];
+    bus.on(EventType.TRIP_CANCELLED, (payload) => emitted.push(payload));
+
     tripHandler.updateTripSwitch(false, OriginType.REGULAR_SWITCH, false);
+
     expect(mockAudio.stop).toHaveBeenCalled();
-    expect(mockStateHandler.resetTimers).toHaveBeenCalled();
+    expect(emitted).toHaveLength(1);
   });
 
-  it('disarms when trip cancelled while triggered and stateChanged=false', () => {
+  it('emits TRIP_CANCELLED with stateChanged=false when trip cancelled while triggered', () => {
     state.currentState = SecurityState.TRIGGERED;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let payload: any;
+    bus.on(EventType.TRIP_CANCELLED, (p) => {
+      payload = p;
+    });
+
     tripHandler.updateTripSwitch(false, OriginType.REGULAR_SWITCH, false);
-    expect(mockStateHandler.updateTargetState).toHaveBeenCalledWith(SecurityState.OFF, OriginType.INTERNAL, 0);
+
+    expect(payload).toBeDefined();
+    expect(payload.stateChanged).toBe(false);
   });
 
-  it('does not disarm when stateChanged=true', () => {
+  it('emits TRIP_CANCELLED with stateChanged=true when state has changed', () => {
     state.currentState = SecurityState.TRIGGERED;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let payload: any;
+    bus.on(EventType.TRIP_CANCELLED, (p) => {
+      payload = p;
+    });
+
     tripHandler.updateTripSwitch(false, OriginType.INTERNAL, true);
-    expect(mockStateHandler.updateTargetState).not.toHaveBeenCalled();
+
+    expect(payload).toBeDefined();
+    expect(payload.stateChanged).toBe(true);
   });
 
   it('triggerIfModeSet allows when current mode matches required', () => {

--- a/src/timers/timer-manager.ts
+++ b/src/timers/timer-manager.ts
@@ -1,0 +1,158 @@
+import type { Logging } from 'homebridge';
+
+type TimerHandle = ReturnType<typeof setTimeout> | null;
+type IntervalHandle = ReturnType<typeof setInterval> | null;
+
+/**
+ * Centralised owner of all timer and interval handles used by the security
+ * system. Handlers call set/clear methods here rather than mutating the shared
+ * SystemState directly, giving a single place where timer lifecycle is managed.
+ */
+export class TimerManager {
+  private armTimer: TimerHandle = null;
+  private pauseTimer: TimerHandle = null;
+  private triggerTimer: TimerHandle = null;
+  private doubleKnockTimer: TimerHandle = null;
+  private resetTimer: TimerHandle = null;
+  private trippedInterval: IntervalHandle = null;
+  private triggeredInterval: IntervalHandle = null;
+
+  constructor(private readonly log: Logging) {}
+
+  // ── Arm timer ──────────────────────────────────────────────────────────────
+
+  setArmTimer(ms: number, cb: () => void): void {
+    this.clearArmTimer();
+    this.armTimer = setTimeout(() => {
+      this.armTimer = null;
+      cb();
+    }, ms);
+  }
+
+  clearArmTimer(): void {
+    if (this.armTimer) {
+      clearTimeout(this.armTimer);
+      this.armTimer = null;
+      this.log.debug('Arming timeout (Cleared)');
+    }
+  }
+
+  // ── Trigger timer ──────────────────────────────────────────────────────────
+
+  setTriggerTimer(ms: number, cb: () => void): void {
+    this.clearTriggerTimer();
+    this.triggerTimer = setTimeout(() => {
+      this.triggerTimer = null;
+      cb();
+    }, ms);
+  }
+
+  clearTriggerTimer(): void {
+    if (this.triggerTimer) {
+      clearTimeout(this.triggerTimer);
+      this.triggerTimer = null;
+      this.log.debug('Trigger timeout (Cleared)');
+    }
+  }
+
+  isTriggerRunning(): boolean {
+    return this.triggerTimer !== null;
+  }
+
+  // ── Pause timer ────────────────────────────────────────────────────────────
+
+  setPauseTimer(ms: number, cb: () => void): void {
+    this.clearPauseTimer();
+    this.pauseTimer = setTimeout(() => {
+      this.pauseTimer = null;
+      cb();
+    }, ms);
+  }
+
+  clearPauseTimer(): void {
+    if (this.pauseTimer) {
+      clearTimeout(this.pauseTimer);
+      this.pauseTimer = null;
+      this.log.debug('Pause timeout (Cleared)');
+    }
+  }
+
+  // ── Double-knock timer ─────────────────────────────────────────────────────
+
+  setDoubleKnockTimer(ms: number, cb: () => void): void {
+    this.clearDoubleKnockTimer();
+    this.doubleKnockTimer = setTimeout(() => {
+      this.doubleKnockTimer = null;
+      cb();
+    }, ms);
+  }
+
+  clearDoubleKnockTimer(): void {
+    if (this.doubleKnockTimer) {
+      clearTimeout(this.doubleKnockTimer);
+      this.doubleKnockTimer = null;
+      this.log.debug('Double-knock timeout (Cleared)');
+    }
+  }
+
+  // ── Reset timer ────────────────────────────────────────────────────────────
+
+  setResetTimer(ms: number, cb: () => void): void {
+    this.clearResetTimer();
+    this.resetTimer = setTimeout(() => {
+      this.resetTimer = null;
+      cb();
+    }, ms);
+  }
+
+  clearResetTimer(): void {
+    if (this.resetTimer) {
+      clearTimeout(this.resetTimer);
+      this.resetTimer = null;
+      this.log.debug('Reset timeout (Cleared)');
+    }
+  }
+
+  // ── Tripped motion sensor interval ─────────────────────────────────────────
+
+  setTrippedInterval(ms: number, cb: () => void): void {
+    this.clearTrippedInterval();
+    this.trippedInterval = setInterval(cb, ms);
+  }
+
+  clearTrippedInterval(): void {
+    if (this.trippedInterval) {
+      clearInterval(this.trippedInterval);
+      this.trippedInterval = null;
+      this.log.debug('Tripped interval (Cleared)');
+    }
+  }
+
+  // ── Triggered motion sensor interval ─���─────────────────────────────────────
+
+  setTriggeredInterval(ms: number, cb: () => void): void {
+    this.clearTriggeredInterval();
+    this.triggeredInterval = setInterval(cb, ms);
+  }
+
+  clearTriggeredInterval(): void {
+    if (this.triggeredInterval) {
+      clearInterval(this.triggeredInterval);
+      this.triggeredInterval = null;
+      this.log.debug('Triggered interval (Cleared)');
+    }
+  }
+
+  // ── Bulk clear ─────────────────────────────────────────────────────────────
+
+  /** Clears every active timer and interval. */
+  clearAll(): void {
+    this.clearTriggerTimer();
+    this.clearArmTimer();
+    this.clearTriggeredInterval();
+    this.clearTrippedInterval();
+    this.clearDoubleKnockTimer();
+    this.clearPauseTimer();
+    this.clearResetTimer();
+  }
+}

--- a/src/types/event-payload-map-type.ts
+++ b/src/types/event-payload-map-type.ts
@@ -4,6 +4,9 @@ import type {
   CurrentChangedPayload,
   ArmingPayload,
   WarningPayload,
+  TriggerFiredPayload,
+  TripCancelledPayload,
+  EmptyPayload,
 } from './event-type.js';
 
 /** Maps each EventType to the payload type emitted with it. */
@@ -12,4 +15,9 @@ export type EventPayloadMap = {
   [EventType.CURRENT_CHANGED]: CurrentChangedPayload;
   [EventType.ARMING]: ArmingPayload;
   [EventType.WARNING]: WarningPayload;
+  [EventType.RESET_TRIP_SWITCHES]: EmptyPayload;
+  [EventType.RESET_MODE_SWITCHES]: EmptyPayload;
+  [EventType.UPDATE_MODE_SWITCHES]: EmptyPayload;
+  [EventType.TRIGGER_FIRED]: TriggerFiredPayload;
+  [EventType.TRIP_CANCELLED]: TripCancelledPayload;
 };

--- a/src/types/event-type.ts
+++ b/src/types/event-type.ts
@@ -7,6 +7,16 @@ export enum EventType {
   CURRENT_CHANGED = 'current-changed',
   ARMING = 'arming',
   WARNING = 'warning',
+
+  // Emitted by StateHandler before TARGET_CHANGED/CURRENT_CHANGED;
+  // consumed by TripHandler and SwitchHandler to reset their own state.
+  RESET_TRIP_SWITCHES = 'reset-trip-switches',
+  RESET_MODE_SWITCHES = 'reset-mode-switches',
+  UPDATE_MODE_SWITCHES = 'update-mode-switches',
+
+  // Emitted by TripHandler; consumed by SecuritySystem which calls into StateHandler.
+  TRIGGER_FIRED = 'trigger-fired',
+  TRIP_CANCELLED = 'trip-cancelled',
 }
 
 export interface TargetChangedPayload {
@@ -27,3 +37,15 @@ export interface WarningPayload {
   origin: OriginType;
   triggerSeconds: number;
 }
+
+export interface TriggerFiredPayload {
+  origin: OriginType;
+}
+
+export interface TripCancelledPayload {
+  origin: OriginType;
+  stateChanged: boolean;
+}
+
+/** Empty payload for internal coordination events. */
+export type EmptyPayload = Record<string, never>;

--- a/src/utils/arming-util.ts
+++ b/src/utils/arming-util.ts
@@ -1,0 +1,44 @@
+import { SecurityState } from '../types/security-state-type.js';
+
+/** Subset of SecuritySystemOptions needed for arming delay resolution. */
+interface ArmingOptions {
+  armSeconds: number;
+  homeArmSeconds: number | null;
+  awayArmSeconds: number | null;
+  nightArmSeconds: number | null;
+}
+
+/** Subset of SystemState needed for arming delay resolution. */
+interface ArmingState {
+  currentState: SecurityState;
+}
+
+/**
+ * Resolves the arming delay in seconds for the given target state.
+ * Returns 0 when disarming (OFF) or when currently triggered.
+ * Falls back to the global `armSeconds` when no mode-specific override is set.
+ */
+export function getArmingSeconds(
+  state: ArmingState,
+  options: ArmingOptions,
+  targetState: SecurityState,
+): number {
+  const isTriggered = state.currentState === SecurityState.TRIGGERED;
+  const isOff = targetState === SecurityState.OFF;
+
+  if (isTriggered || isOff) {
+    return 0;
+  }
+
+  if (targetState === SecurityState.HOME && options.homeArmSeconds !== null) {
+    return options.homeArmSeconds;
+  }
+  if (targetState === SecurityState.AWAY && options.awayArmSeconds !== null) {
+    return options.awayArmSeconds;
+  }
+  if (targetState === SecurityState.NIGHT && options.nightArmSeconds !== null) {
+    return options.nightArmSeconds;
+  }
+
+  return options.armSeconds;
+}


### PR DESCRIPTION
Both functions duplicated logic already present in utils/state-util.ts and
StateHandler. Replace modeToStateVal with modeToState() from state-util,
and calcAvailableStates with an equivalent inline using the same utility.

https://claude.ai/code/session_01Pid7KoNpdFqQMTUNhV4tXe

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Restructured internal architecture to centralize timer management and improve handler coordination through event-driven communication.
  * Reorganized HomeKit integration code for better maintainability and clearer separation of concerns.
  
* **Bug Fixes**
  * Improved trigger and trip state tracking accuracy through refined state management logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->