### PR TITLE
feat: add custom trip mode switches per mode via config

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -404,6 +404,57 @@
         "default": true,
         "required": false
       },
+      "trip_home_switches": {
+        "title": "Custom Trip Home Switches",
+        "description": "Additional trip switches for Home mode. Final name is \"Home <Label>\".",
+        "type": "array",
+        "items": {
+          "title": "Switch",
+          "type": "object",
+          "properties": {
+            "label": {
+              "title": "Label",
+              "type": "string",
+              "required": true
+            }
+          }
+        },
+        "required": false
+      },
+      "trip_away_switches": {
+        "title": "Custom Trip Away Switches",
+        "description": "Additional trip switches for Away mode. Final name is \"Away <Label>\".",
+        "type": "array",
+        "items": {
+          "title": "Switch",
+          "type": "object",
+          "properties": {
+            "label": {
+              "title": "Label",
+              "type": "string",
+              "required": true
+            }
+          }
+        },
+        "required": false
+      },
+      "trip_night_switches": {
+        "title": "Custom Trip Night Switches",
+        "description": "Additional trip switches for Night mode. Final name is \"Night <Label>\".",
+        "type": "array",
+        "items": {
+          "title": "Switch",
+          "type": "object",
+          "properties": {
+            "label": {
+              "title": "Label",
+              "type": "string",
+              "required": true
+            }
+          }
+        },
+        "required": false
+      },
       "audio_switch": {
         "title": "Show Audio Switch",
         "description": "Adds a global switch to enable or disable audio except for alarm triggered.",
@@ -759,6 +810,24 @@
         "trip_switch",
         "trip_override_switch",
         "trip_mode_switches",
+        {
+          "key": "trip_home_switches",
+          "type": "tabarray",
+          "title": "{{ value.label || 'Home Switch' }}",
+          "items": ["trip_home_switches[].label"]
+        },
+        {
+          "key": "trip_away_switches",
+          "type": "tabarray",
+          "title": "{{ value.label || 'Away Switch' }}",
+          "items": ["trip_away_switches[].label"]
+        },
+        {
+          "key": "trip_night_switches",
+          "type": "tabarray",
+          "title": "{{ value.label || 'Night Switch' }}",
+          "items": ["trip_night_switches[].label"]
+        },
         "audio_switch"
       ]
     },

--- a/src/handlers/trip-handler.ts
+++ b/src/handlers/trip-handler.ts
@@ -124,6 +124,21 @@ export class TripHandler {
         this.log.debug(`${label} Switch (Off)`);
       }
     }
+
+    const customGroups = [
+      this.services.customTripHomeSwitchServices,
+      this.services.customTripAwaySwitchServices,
+      this.services.customTripNightSwitchServices,
+    ];
+
+    for (const group of customGroups) {
+      for (const svc of group) {
+        const char = svc.getCharacteristic(this.Characteristic.On);
+        if (char.value) {
+          char.updateValue(false);
+        }
+      }
+    }
   }
 
   private activateTrip(origin: OriginType): void {

--- a/src/homekit/homekit-registrar.ts
+++ b/src/homekit/homekit-registrar.ts
@@ -1,4 +1,4 @@
-import type { API, Logging, CharacteristicValue } from 'homebridge';
+import type { API, Logging, CharacteristicValue, Service } from 'homebridge';
 import { HAPStatus } from 'homebridge';
 import type { CharacteristicConstructor } from '../interfaces/hap-types-interface.js';
 import type { ServiceRegistry } from '../interfaces/service-registry-interface.js';
@@ -66,6 +66,26 @@ export class HomeKitRegistrar {
             throw new this.api.hap.HapStatusError(HK_ERR as HAPStatus);
           }
         });
+    }
+
+    const customModeTrips: Array<[Service[], SecurityState]> = [
+      [s.customTripHomeSwitchServices, SecurityState.HOME],
+      [s.customTripAwaySwitchServices, SecurityState.AWAY],
+      [s.customTripNightSwitchServices, SecurityState.NIGHT],
+    ];
+    for (const [services, mode] of customModeTrips) {
+      for (const svc of services) {
+        const name = String(svc.getCharacteristic(Char.ConfiguredName).value ?? 'Custom Trip');
+        svc.getCharacteristic(Char.On)
+          .onGet(async () => Boolean(svc.getCharacteristic(Char.On).value))
+          .onSet(async (v: CharacteristicValue) => {
+            this.log.info(`${name} Switch (${v ? 'On' : 'Off'})`);
+            const ok = this.tripHandler.triggerIfModeSet(mode, v as boolean);
+            if (!ok) {
+              throw new this.api.hap.HapStatusError(HK_ERR as HAPStatus);
+            }
+          });
+      }
     }
 
     s.tripOverrideSwitchService.getCharacteristic(Char.On)

--- a/src/homekit/service-factory.ts
+++ b/src/homekit/service-factory.ts
@@ -1,6 +1,6 @@
 import type { Service } from 'homebridge';
 import type { CharacteristicConstructor } from '../interfaces/hap-types-interface.js';
-import type { SecuritySystemOptions } from '../interfaces/options-interface.js';
+import type { SecuritySystemOptions, TripModeSwitch } from '../interfaces/options-interface.js';
 import type { ServiceRegistry } from '../interfaces/service-registry-interface.js';
 import type { SystemState } from '../interfaces/system-state-interface.js';
 import { SecurityState } from '../types/security-state-type.js';
@@ -37,6 +37,9 @@ export function buildServiceRegistry(
   const audioSvc = sw(options.audioSwitchName, SWITCH_UUIDS.AUDIO);
   audioSvc.getCharacteristic(Char.On).value = true;
 
+  const buildCustomTripSwitches = (mode: string, modeLabel: string, switches: TripModeSwitch[]): Service[] =>
+    switches.map((s, i) => sw(`${modeLabel} ${s.label}`, `trip-${mode}-${i}`));
+
   return {
     mainService: mainSvc,
     accessoryInfoService: infoSvc,
@@ -55,6 +58,9 @@ export function buildServiceRegistry(
     modeOffSwitchService: sw(options.modeOffSwitchName, SWITCH_UUIDS.MODE_OFF),
     modeAwayExtendedSwitchService: sw(options.modeAwayExtendedSwitchName, SWITCH_UUIDS.MODE_AWAY_EXTENDED),
     modePauseSwitchService: sw(options.modePauseSwitchName, SWITCH_UUIDS.MODE_PAUSE),
+    customTripHomeSwitchServices: buildCustomTripSwitches('home', 'Home', options.tripHomeSwitches),
+    customTripAwaySwitchServices: buildCustomTripSwitches('away', 'Away', options.tripAwaySwitches),
+    customTripNightSwitchServices: buildCustomTripSwitches('night', 'Night', options.tripNightSwitches),
     audioSwitchService: audioSvc,
     armingMotionSensorService: sensor('Arming', SWITCH_UUIDS.ARMING_SENSOR),
     trippedMotionSensorService: sensor('Tripped', SWITCH_UUIDS.TRIPPED_SENSOR),
@@ -104,6 +110,7 @@ export function buildServiceList(
     if (options.tripModeSwitches) {
       list.push(svcs.tripHomeSwitchService);
     }
+    list.push(...svcs.customTripHomeSwitchServices);
   }
   if (avail.includes(SecurityState.AWAY)) {
     if (options.modeSwitches) {
@@ -112,6 +119,7 @@ export function buildServiceList(
     if (options.tripModeSwitches) {
       list.push(svcs.tripAwaySwitchService);
     }
+    list.push(...svcs.customTripAwaySwitchServices);
   }
   if (avail.includes(SecurityState.NIGHT)) {
     if (options.modeSwitches) {
@@ -120,6 +128,7 @@ export function buildServiceList(
     if (options.tripModeSwitches) {
       list.push(svcs.tripNightSwitchService);
     }
+    list.push(...svcs.customTripNightSwitchServices);
   }
 
   if (options.modeSwitches && options.modeOffSwitch) {

--- a/src/interfaces/options-interface.ts
+++ b/src/interfaces/options-interface.ts
@@ -4,6 +4,11 @@ export interface AudioVariable {
   value: string;
 }
 
+/** A single custom trip switch entry with a user-defined label. */
+export interface TripModeSwitch {
+  label: string;
+}
+
 /** Fully-parsed, strongly-typed configuration options for the security system. */
 export interface SecuritySystemOptions {
   name: string;
@@ -50,6 +55,11 @@ export interface SecuritySystemOptions {
   tripSwitch: boolean;
   tripOverrideSwitch: boolean;
   tripModeSwitches: boolean;
+
+  // Custom trip mode switches
+  tripHomeSwitches: TripModeSwitch[];
+  tripAwaySwitches: TripModeSwitch[];
+  tripNightSwitches: TripModeSwitch[];
 
   // Arming lock
   armingLockSwitch: boolean;

--- a/src/interfaces/service-registry-interface.ts
+++ b/src/interfaces/service-registry-interface.ts
@@ -26,6 +26,11 @@ export interface ServiceRegistry {
   modeAwayExtendedSwitchService: Service;
   modePauseSwitchService: Service;
 
+  // Custom trip mode switches (dynamic, one per configured entry)
+  customTripHomeSwitchServices: Service[];
+  customTripAwaySwitchServices: Service[];
+  customTripNightSwitchServices: Service[];
+
   // Audio switch
   audioSwitchService: Service;
 

--- a/src/services/configuration-service.ts
+++ b/src/services/configuration-service.ts
@@ -161,6 +161,17 @@ export class ConfigurationService {
       audioExtraVariables: Array.isArray(raw.audio_extra_variables)
         ? (raw.audio_extra_variables as { key: string; value: string }[])
         : [],
+
+      // Custom trip mode switches
+      tripHomeSwitches: Array.isArray(raw.trip_home_switches)
+        ? (raw.trip_home_switches as { label: string }[])
+        : [],
+      tripAwaySwitches: Array.isArray(raw.trip_away_switches)
+        ? (raw.trip_away_switches as { label: string }[])
+        : [],
+      tripNightSwitches: Array.isArray(raw.trip_night_switches)
+        ? (raw.trip_night_switches as { label: string }[])
+        : [],
       audioSwitch: this.bool(raw, 'audio_switch', false),
 
       // Server


### PR DESCRIPTION
Allows users to define arrays of labeled trip switches per mode
(Home, Away, Night) using trip_home_switches, trip_away_switches,
and trip_night_switches in the plugin config. Each switch gets a
name of "<Mode> <Label>" and a stable UUID subtype derived from
mode + index so renaming the label never changes HomeKit identity.
Switches use the existing triggerIfModeSet path and are reset with
all other trip switches on state change.

https://claude.ai/code/session_01RdQEbZyYXvMU7jdZnqsChZ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Configure custom switches for Home, Away, and Night trip modes. Each custom switch can be individually labeled and controlled, providing enhanced flexibility for security automation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->