### PR TITLE
fix: resolve Service|Service[] type errors and CHANGELOG detection bug

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -113,14 +113,13 @@ jobs:
 
       - name: Commit changelog
         run: |
-          if git diff --quiet CHANGELOG.md; then
-            echo "No changelog updates to commit."
-            exit 0
-          fi
-
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add CHANGELOG.md
+          if git diff --quiet --cached CHANGELOG.md; then
+            echo "No changelog updates to commit."
+            exit 0
+          fi
           git commit -m "docs: update changelog for ${{ needs.create-tag.outputs.tag-name }}"
           git push origin HEAD:main
 

--- a/src/handlers/sensor-handler.ts
+++ b/src/handlers/sensor-handler.ts
@@ -1,4 +1,4 @@
-import type { Logging } from 'homebridge';
+import type { Logging, Service } from 'homebridge';
 import { SENSOR_PULSE_MS } from '../constants/homekit-constant.js';
 import type { ServiceRegistry } from '../interfaces/service-registry-interface.js';
 import type { CharacteristicConstructor } from '../interfaces/hap-types-interface.js';
@@ -73,7 +73,7 @@ export class SensorHandler {
 
   // ── Private helpers ────────────────────────────────────────────────────────
 
-  private scheduleReset(service: ServiceRegistry[keyof ServiceRegistry]): void {
+  private scheduleReset(service: Service): void {
     setTimeout(() => {
       service.updateCharacteristic(this.Characteristic.MotionDetected, false);
     }, SENSOR_PULSE_MS);

--- a/src/handlers/state-handler.ts
+++ b/src/handlers/state-handler.ts
@@ -4,7 +4,7 @@ import { SecurityState } from '../types/security-state-type.js';
 import { OriginType } from '../types/origin-type.js';
 import { stateToMode, capitalise } from '../utils/state-util.js';
 import { modeToState } from '../utils/state-util.js';
-import type { ServiceRegistry } from '../interfaces/service-registry-interface.js';
+import type { ServiceRegistry, SingleServiceKey } from '../interfaces/service-registry-interface.js';
 import type { SystemState } from '../interfaces/system-state-interface.js';
 import type { SecuritySystemOptions } from '../interfaces/options-interface.js';
 import type { EventBusService } from '../services/event-bus-service.js';
@@ -116,7 +116,7 @@ export class StateHandler {
       return true;
     }
 
-    const modeMap: Partial<Record<SecurityState, keyof ServiceRegistry>> = {
+    const modeMap: Partial<Record<SecurityState, SingleServiceKey>> = {
       [SecurityState.HOME]: 'armingLockHomeSwitchService',
       [SecurityState.AWAY]: 'armingLockAwaySwitchService',
       [SecurityState.NIGHT]: 'armingLockNightSwitchService',

--- a/src/handlers/switch-handler.ts
+++ b/src/handlers/switch-handler.ts
@@ -2,7 +2,7 @@ import type { Logging } from 'homebridge';
 import type { CharacteristicConstructor } from '../interfaces/hap-types-interface.js';
 import { SecurityState } from '../types/security-state-type.js';
 import { HK_NOT_ALLOWED_IN_CURRENT_STATE } from '../constants/homekit-constant.js';
-import type { ServiceRegistry } from '../interfaces/service-registry-interface.js';
+import type { ServiceRegistry, SingleServiceKey } from '../interfaces/service-registry-interface.js';
 import type { SystemState } from '../interfaces/system-state-interface.js';
 import type { SecuritySystemOptions } from '../interfaces/options-interface.js';
 import type { StateHandler } from './state-handler.js';
@@ -101,7 +101,7 @@ export class SwitchHandler {
   updateArmingLock(mode: string, value: boolean): boolean {
     this.logArmingLock(mode, value);
 
-    const map: Record<string, keyof ServiceRegistry> = {
+    const map: Record<string, SingleServiceKey> = {
       global: 'armingLockSwitchService',
       home: 'armingLockHomeSwitchService',
       away: 'armingLockAwaySwitchService',
@@ -121,7 +121,7 @@ export class SwitchHandler {
   // ── Mode switch display ────────────────────────────────────────────────────
 
   resetModeSwitches(): void {
-    const switches: Array<keyof ServiceRegistry> = [
+    const switches: Array<SingleServiceKey> = [
       'modeHomeSwitchService', 'modeAwaySwitchService', 'modeNightSwitchService',
       'modeOffSwitchService', 'modeAwayExtendedSwitchService', 'modePauseSwitchService',
     ];
@@ -136,7 +136,7 @@ export class SwitchHandler {
   }
 
   updateModeSwitches(): void {
-    const modeMap: Partial<Record<SecurityState, keyof ServiceRegistry>> = {
+    const modeMap: Partial<Record<SecurityState, SingleServiceKey>> = {
       [SecurityState.HOME]: 'modeHomeSwitchService',
       [SecurityState.AWAY]: 'modeAwaySwitchService',
       [SecurityState.NIGHT]: 'modeNightSwitchService',

--- a/src/handlers/trip-handler.ts
+++ b/src/handlers/trip-handler.ts
@@ -2,7 +2,7 @@ import type { Logging } from 'homebridge';
 import type { CharacteristicConstructor } from '../interfaces/hap-types-interface.js';
 import { SecurityState } from '../types/security-state-type.js';
 import { OriginType } from '../types/origin-type.js';
-import type { ServiceRegistry } from '../interfaces/service-registry-interface.js';
+import type { ServiceRegistry, SingleServiceKey } from '../interfaces/service-registry-interface.js';
 import type { SystemState } from '../interfaces/system-state-interface.js';
 import type { SecuritySystemOptions } from '../interfaces/options-interface.js';
 import type { EventBusService } from '../services/event-bus-service.js';
@@ -110,7 +110,7 @@ export class TripHandler {
   }
 
   resetTripSwitches(): void {
-    const switches: Array<[keyof ServiceRegistry, string]> = [
+    const switches: Array<[SingleServiceKey, string]> = [
       ['tripHomeSwitchService', 'Trip Home'],
       ['tripAwaySwitchService', 'Trip Away'],
       ['tripNightSwitchService', 'Trip Night'],

--- a/src/homekit/homekit-registrar.ts
+++ b/src/homekit/homekit-registrar.ts
@@ -1,7 +1,7 @@
 import type { API, Logging, CharacteristicValue, Service } from 'homebridge';
 import { HAPStatus } from 'homebridge';
 import type { CharacteristicConstructor } from '../interfaces/hap-types-interface.js';
-import type { ServiceRegistry } from '../interfaces/service-registry-interface.js';
+import type { ServiceRegistry, SingleServiceKey } from '../interfaces/service-registry-interface.js';
 import type { SystemState } from '../interfaces/system-state-interface.js';
 import { SecurityState } from '../types/security-state-type.js';
 import { OriginType } from '../types/origin-type.js';
@@ -50,7 +50,7 @@ export class HomeKitRegistrar {
         tripSetHandler(v, OriginType.REGULAR_SWITCH);
       });
 
-    const modeTrips: Array<[keyof ServiceRegistry, SecurityState, string]> = [
+    const modeTrips: Array<[SingleServiceKey, SecurityState, string]> = [
       ['tripHomeSwitchService', SecurityState.HOME, 'Trip Home'],
       ['tripAwaySwitchService', SecurityState.AWAY, 'Trip Away'],
       ['tripNightSwitchService', SecurityState.NIGHT, 'Trip Night'],
@@ -96,7 +96,7 @@ export class HomeKitRegistrar {
       });
 
     // Mode switches.
-    const modeSwitches: Array<[keyof ServiceRegistry, SecurityState | null, string]> = [
+    const modeSwitches: Array<[SingleServiceKey, SecurityState | null, string]> = [
       ['modeHomeSwitchService', SecurityState.HOME, 'Mode Home'],
       ['modeAwaySwitchService', SecurityState.AWAY, 'Mode Away'],
       ['modeNightSwitchService', SecurityState.NIGHT, 'Mode Night'],
@@ -136,7 +136,7 @@ export class HomeKitRegistrar {
       });
 
     // Arming lock switches.
-    const lockSwitches: Array<[keyof ServiceRegistry, string]> = [
+    const lockSwitches: Array<[SingleServiceKey, string]> = [
       ['armingLockSwitchService', 'global'],
       ['armingLockHomeSwitchService', 'home'],
       ['armingLockAwaySwitchService', 'away'],

--- a/src/interfaces/service-registry-interface.ts
+++ b/src/interfaces/service-registry-interface.ts
@@ -40,3 +40,8 @@ export interface ServiceRegistry {
   triggeredMotionSensorService: Service;
   triggeredResetMotionSensorService: Service;
 }
+
+/** Keys of ServiceRegistry whose value is a single Service (not Service[]). */
+export type SingleServiceKey = {
+  [K in keyof ServiceRegistry]: ServiceRegistry[K] extends Service[] ? never : K;
+}[keyof ServiceRegistry];


### PR DESCRIPTION
Add SingleServiceKey utility type to ServiceRegistry so that indexed
lookups on single-service keys resolve to Service (not Service|Service[]),
eliminating all getCharacteristic/updateCharacteristic type errors.

Fix CHANGELOG commit step: stage the file first then use
git diff --cached so new files (first-ever CHANGELOG) are detected
correctly and actually committed.

https://claude.ai/code/session_01F2do1wu9uqh8sGtCMzP6na