### PR TITLE
Replace numeric server code with string-based API key authentication

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -536,7 +536,7 @@
         "minimum": 0,
         "placeholder": 80
       },
-      "server_code": {
+      "server_api_key": {
         "title": "API Key",
         "description": "A key used to protect the server and authenticate requests.",
         "type": "string",

--- a/config.schema.json
+++ b/config.schema.json
@@ -537,12 +537,11 @@
         "placeholder": 80
       },
       "server_code": {
-        "title": "Security Code",
-        "description": "All requests will require this code to be sent.",
-        "type": "integer",
+        "title": "API Key",
+        "description": "A key used to protect the server and authenticate requests.",
+        "type": "string",
         "required": false,
-        "minimum": 0,
-        "placeholder": "XXXX"
+        "placeholder": "your-api-key"
       },
       "webhook_url": {
         "title": "Base URL",

--- a/src/interfaces/options-interface.ts
+++ b/src/interfaces/options-interface.ts
@@ -101,7 +101,7 @@ export interface SecuritySystemOptions {
 
   // Server
   serverPort: number | null;
-  serverCode: string | null;
+  serverApiKey: string | null;
 
   // Shell commands
   commandTargetHome: string | null;

--- a/src/interfaces/options-interface.ts
+++ b/src/interfaces/options-interface.ts
@@ -101,7 +101,7 @@ export interface SecuritySystemOptions {
 
   // Server
   serverPort: number | null;
-  serverCode: number | null;
+  serverCode: string | null;
 
   // Shell commands
   commandTargetHome: string | null;

--- a/src/services/configuration-service.ts
+++ b/src/services/configuration-service.ts
@@ -176,7 +176,8 @@ export class ConfigurationService {
 
       // Server
       serverPort: this.num(raw, 'server_port'),
-      serverCode: this.str(raw, 'server_code'),
+      // TODO: Remove serverCode fallback in future major version
+      serverApiKey: this.str(raw, 'server_api_key') ?? (this.num(raw, 'server_code') !== null ? String(this.num(raw, 'server_code')!) : null),
 
       // Shell commands
       commandTargetHome: this.str(raw, 'command_target_home'),

--- a/src/services/configuration-service.ts
+++ b/src/services/configuration-service.ts
@@ -176,7 +176,7 @@ export class ConfigurationService {
 
       // Server
       serverPort: this.num(raw, 'server_port'),
-      serverCode: this.num(raw, 'server_code'),
+      serverCode: this.str(raw, 'server_code'),
 
       // Shell commands
       commandTargetHome: this.str(raw, 'command_target_home'),

--- a/src/services/server-service.ts
+++ b/src/services/server-service.ts
@@ -160,7 +160,7 @@ export class ServerService {
     this.application.openAPIRegistry.registerComponent('securitySchemes', 'BearerAuth', {
       type: 'http',
       scheme: 'bearer',
-      description: 'Numeric API key configured via the serverCode plugin option.',
+      description: 'API key configured via the server_api_key plugin option.',
     });
 
     // OpenAPI spec
@@ -226,11 +226,11 @@ export class ServerService {
   }
 
   /**
-   * Validates the Authorization: Bearer <key> header when serverCode is configured.
+   * Validates the Authorization: Bearer <key> header when serverApiKey is configured.
    * Returns an error Response on failure, or null to allow the request through.
    */
   private authenticate(context: Context): Response | null {
-    if (this.options.serverCode === null) {
+    if (this.options.serverApiKey === null) {
       return null;
     }
 
@@ -254,7 +254,7 @@ export class ServerService {
 
     const code = authHeader.slice('Bearer '.length).trim();
 
-    if (parseInt(code, 10) !== this.options.serverCode) {
+    if (code !== this.options.serverApiKey) {
       this.state.invalidCodeCount++;
       this.log.info('Code invalid (Server)');
       return context.json({ reason: 'API key invalid' }, 403) as Response;


### PR DESCRIPTION
## Summary
This PR refactors the server authentication mechanism from a numeric security code to a string-based API key system. This change provides better flexibility for API key formats and improves the authentication model.

## Key Changes
- **Configuration Schema**: Updated `server_code` to `server_api_key` with type changed from `integer` to `string`
- **Authentication Logic**: Modified the `authenticate()` method to perform string comparison instead of numeric parsing
- **Type Definitions**: Updated `SecuritySystemOptions` interface to reflect `serverApiKey: string | null` instead of `serverCode: number | null`
- **Backward Compatibility**: Added fallback logic in `ConfigurationService` to convert legacy numeric `server_code` values to strings, with a TODO comment for removal in a future major version
- **Documentation**: Updated OpenAPI security scheme description and code comments to reference the new `server_api_key` option

## Implementation Details
- The authentication header validation now performs a direct string comparison (`code !== this.options.serverApiKey`) instead of parsing the code as an integer
- Legacy configurations using `server_code` will automatically convert their numeric values to strings, ensuring a smooth migration path
- The placeholder in the schema was updated from `"XXXX"` to `"your-api-key"` to better reflect the expected format

https://claude.ai/code/session_01EAaKRRUHy5fEsbTiQNXkKn