### PR TITLE
Improve API authentication logging and naming clarity

### DIFF
--- a/src/interfaces/system-state-interface.ts
+++ b/src/interfaces/system-state-interface.ts
@@ -11,7 +11,7 @@ export interface SystemState {
   isArming: boolean;
   isTripping: boolean;
   isKnocked: boolean;
-  invalidCodeCount: number;
+  serverAuthenticationAttempts: number;
   pausedCurrentState: SecurityState | null;
   audioProcess: ChildProcess | null;
 }

--- a/src/security-system.ts
+++ b/src/security-system.ts
@@ -148,7 +148,7 @@ export class SecuritySystem implements AccessoryPlugin {
       isArming: false,
       isTripping: false,
       isKnocked: false,
-      invalidCodeCount: 0,
+      serverAuthenticationAttempts: 0,
       pausedCurrentState: null,
       audioProcess: null,
     };

--- a/src/services/server-service.ts
+++ b/src/services/server-service.ts
@@ -237,30 +237,30 @@ export class ServerService {
     const authHeader = context.req.header('Authorization');
 
     if (authHeader === undefined || !authHeader.startsWith('Bearer ')) {
-      this.log.info('Code required (Server)');
+      this.log.info('API key required - Authorization header missing (Server)');
       return context.json(
         { reason: 'API key required. Use the Authorization: Bearer <key> header.' },
         401,
       ) as Response;
     }
 
-    if (this.state.invalidCodeCount >= 5) {
-      this.log.info('Code blocked (Server)');
+    if (this.state.serverAuthenticationAttempts >= 5) {
+      this.log.warn('API key blocked - too many invalid attempts (Server)');
       return context.json(
         { reason: 'API key blocked due to too many invalid attempts' },
         403,
       ) as Response;
     }
 
-    const code = authHeader.slice('Bearer '.length).trim();
+    const apiKey = authHeader.slice('Bearer '.length).trim();
 
-    if (code !== this.options.serverApiKey) {
-      this.state.invalidCodeCount++;
-      this.log.info('Code invalid (Server)');
+    if (apiKey !== this.options.serverApiKey) {
+      this.state.serverAuthenticationAttempts++;
+      this.log.warn(`API key invalid - attempt ${this.state.serverAuthenticationAttempts}/5 (Server)`);
       return context.json({ reason: 'API key invalid' }, 403) as Response;
     }
 
-    this.state.invalidCodeCount = 0;
+    this.state.serverAuthenticationAttempts = 0;
     return null;
   }
 }

--- a/src/tests/conditions.test.ts
+++ b/src/tests/conditions.test.ts
@@ -20,7 +20,7 @@ function makeState(overrides: Partial<SystemState> = {}): SystemState {
     isArming: false,
     isTripping: false,
     isKnocked: false,
-    invalidCodeCount: 0,
+    serverAuthenticationAttempts: 0,
     pausedCurrentState: null,
     audioProcess: null,
     ...overrides,

--- a/src/tests/state-handler.test.ts
+++ b/src/tests/state-handler.test.ts
@@ -54,7 +54,7 @@ function makeState(overrides: Partial<SystemState> = {}): SystemState {
     isArming: false,
     isTripping: false,
     isKnocked: false,
-    invalidCodeCount: 0,
+    serverAuthenticationAttempts: 0,
     pausedCurrentState: null,
     audioProcess: null,
     ...overrides,

--- a/src/tests/trip-handler.test.ts
+++ b/src/tests/trip-handler.test.ts
@@ -56,7 +56,7 @@ function makeState(overrides: Partial<SystemState> = {}): SystemState {
     isArming: false,
     isTripping: false,
     isKnocked: false,
-    invalidCodeCount: 0,
+    serverAuthenticationAttempts: 0,
     pausedCurrentState: null,
     audioProcess: null,
     ...overrides,


### PR DESCRIPTION
## Summary
Refactored the server API authentication logic to use clearer naming conventions and improved logging messages. This change renames the internal state variable from `invalidCodeCount` to `serverAuthenticationAttempts` and updates all related log messages to be more descriptive and use appropriate log levels.

## Key Changes
- Renamed `invalidCodeCount` to `serverAuthenticationAttempts` throughout the codebase for better semantic clarity
- Updated variable name from `code` to `apiKey` in the authentication validation logic
- Enhanced logging messages:
  - "Code required" → "API key required - Authorization header missing"
  - "Code blocked" → "API key blocked - too many invalid attempts" (upgraded to `warn` level)
  - "Code invalid" → "API key invalid - attempt X/5" (upgraded to `warn` level with attempt counter)
- Updated all test files to use the new state property name

## Notable Details
- The authentication attempt limit remains at 5 attempts
- Log levels were upgraded from `info` to `warn` for blocked and invalid API key scenarios, improving observability
- The attempt counter is reset to 0 on successful authentication
- All changes are backward compatible in terms of functionality, only improving naming and logging

https://claude.ai/code/session_0142zz3iJJojEaLtCmij1tEm