### PR TITLE
refactor: replace boolean returns with ServiceResult objects and add condition failure reasons

### DIFF
--- a/src/conditions/already-triggered-condition.ts
+++ b/src/conditions/already-triggered-condition.ts
@@ -15,6 +15,7 @@ export class AlreadyTriggeredCondition extends Condition {
     }
     const blocked = state.currentState === SecurityState.TRIGGERED;
     if (blocked) {
+      this._failureReason = 'alarm is already active';
       log.warn('Security System (Already triggered): alarm is already active');
     }
     return blocked;

--- a/src/conditions/already-triggered-condition.ts
+++ b/src/conditions/already-triggered-condition.ts
@@ -10,6 +10,7 @@ export class AlreadyTriggeredCondition extends Condition {
   readonly name = 'already-triggered';
 
   evaluate({ state, value, log }: ConditionContext): boolean {
+    this.clearFailureReason();
     if (!value) {
       return false;
     }

--- a/src/conditions/already-triggered-condition.ts
+++ b/src/conditions/already-triggered-condition.ts
@@ -15,8 +15,8 @@ export class AlreadyTriggeredCondition extends Condition {
     }
     const blocked = state.currentState === SecurityState.TRIGGERED;
     if (blocked) {
-      this._failureReason = 'alarm is already active';
-      log.warn('Security System (Already triggered): alarm is already active');
+      this._failureReason = 'Security System (Already triggered): alarm is already active';
+      log.warn(this._failureReason);
     }
     return blocked;
   }

--- a/src/conditions/arming-in-progress-condition.ts
+++ b/src/conditions/arming-in-progress-condition.ts
@@ -13,6 +13,7 @@ export class ArmingInProgressCondition extends Condition {
       return false;
     }
     if (state.isArming) {
+      this._failureReason = 'arm delay countdown is still in progress';
       log.warn('Trip Switch (Still arming): arm delay countdown is still in progress');
       return true;
     }

--- a/src/conditions/arming-in-progress-condition.ts
+++ b/src/conditions/arming-in-progress-condition.ts
@@ -13,8 +13,8 @@ export class ArmingInProgressCondition extends Condition {
       return false;
     }
     if (state.isArming) {
-      this._failureReason = 'arm delay countdown is still in progress';
-      log.warn('Trip Switch (Still arming): arm delay countdown is still in progress');
+      this._failureReason = 'Trip Switch (Still arming): arm delay countdown is still in progress';
+      log.warn(this._failureReason);
       return true;
     }
     return false;

--- a/src/conditions/arming-in-progress-condition.ts
+++ b/src/conditions/arming-in-progress-condition.ts
@@ -9,6 +9,7 @@ export class ArmingInProgressCondition extends Condition {
   readonly name = 'arming-in-progress';
 
   evaluate({ state, value, log }: ConditionContext): boolean {
+    this.clearFailureReason();
     if (!value) {
       return false;
     }

--- a/src/conditions/arming-lock-condition.ts
+++ b/src/conditions/arming-lock-condition.ts
@@ -17,12 +17,12 @@ export class ArmingLockCondition extends Condition {
   evaluate({ state, services, options }: ConditionContext): boolean {
     const hasLockFeature = options.armingLockSwitch || options.armingLockSwitches;
     if (!hasLockFeature) {
-      return false; 
+      return false;
     }
 
     const targetState = state.targetState;
     if (targetState === SecurityState.OFF) {
-      return false; 
+      return false;
     }
 
     // Check global arming-lock switch.
@@ -30,19 +30,28 @@ export class ArmingLockCondition extends Condition {
       .getCharacteristic(this.Characteristic.On).value;
 
     if (globalOn) {
-      return true; 
+      this._failureReason = 'arming is blocked by the global arming lock switch';
+      return true;
     }
 
     // Check mode-specific arming-lock switch.
+    let blocked = false;
     switch (targetState) {
     case SecurityState.HOME:
-      return Boolean(services.armingLockHomeSwitchService.getCharacteristic(this.Characteristic.On).value);
+      blocked = Boolean(services.armingLockHomeSwitchService.getCharacteristic(this.Characteristic.On).value);
+      break;
     case SecurityState.AWAY:
-      return Boolean(services.armingLockAwaySwitchService.getCharacteristic(this.Characteristic.On).value);
+      blocked = Boolean(services.armingLockAwaySwitchService.getCharacteristic(this.Characteristic.On).value);
+      break;
     case SecurityState.NIGHT:
-      return Boolean(services.armingLockNightSwitchService.getCharacteristic(this.Characteristic.On).value);
-    default:
-      return false;
+      blocked = Boolean(services.armingLockNightSwitchService.getCharacteristic(this.Characteristic.On).value);
+      break;
     }
+
+    if (blocked) {
+      this._failureReason = 'arming is blocked by a mode-specific arming lock switch';
+    }
+
+    return blocked;
   }
 }

--- a/src/conditions/arming-lock-condition.ts
+++ b/src/conditions/arming-lock-condition.ts
@@ -15,6 +15,7 @@ export class ArmingLockCondition extends Condition {
   }
 
   evaluate({ state, services, options }: ConditionContext): boolean {
+    this.clearFailureReason();
     const hasLockFeature = options.armingLockSwitch || options.armingLockSwitches;
     if (!hasLockFeature) {
       return false;

--- a/src/conditions/condition.ts
+++ b/src/conditions/condition.ts
@@ -4,10 +4,18 @@ import type { ConditionContext } from '../interfaces/condition-context-interface
  * Base class for all conditions that can block a trip/trigger action.
  *
  * Extend this class and implement `evaluate()` to return `true` when the
- * condition should prevent the action from proceeding.
+ * condition should prevent the action from proceeding. Set `_failureReason`
+ * before returning `true` so callers can retrieve it via `failureReason`.
  */
 export abstract class Condition {
   abstract readonly name: string;
+
+  protected _failureReason: string | undefined;
+
+  /** Returns the reason the condition blocked the last evaluated action, if any. */
+  get failureReason(): string | undefined {
+    return this._failureReason;
+  }
 
   /**
    * Returns `true` if this condition blocks the action described by `context`.

--- a/src/conditions/condition.ts
+++ b/src/conditions/condition.ts
@@ -17,9 +17,15 @@ export abstract class Condition {
     return this._failureReason;
   }
 
+  /** Must be called at the top of every evaluate() implementation to clear any stale reason. */
+  protected clearFailureReason(): void {
+    this._failureReason = undefined;
+  }
+
   /**
    * Returns `true` if this condition blocks the action described by `context`.
    * When `true` is returned the caller must reject the HomeKit request.
+   * Implementations must call `this.clearFailureReason()` before any allow/deny logic.
    */
   abstract evaluate(context: ConditionContext): boolean;
 }

--- a/src/conditions/double-knock-condition.ts
+++ b/src/conditions/double-knock-condition.ts
@@ -60,6 +60,7 @@ export class DoubleKnockCondition extends Condition {
       log.info('Trip Switch (Reset): double-knock window expired without second activation');
     });
 
+    this._failureReason = 'double-knock is required, waiting for second activation';
     log.warn('Trip Switch (Knock): double-knock is required, waiting for second activation');
     return true;
   }

--- a/src/conditions/double-knock-condition.ts
+++ b/src/conditions/double-knock-condition.ts
@@ -60,8 +60,8 @@ export class DoubleKnockCondition extends Condition {
       log.info('Trip Switch (Reset): double-knock window expired without second activation');
     });
 
-    this._failureReason = 'double-knock is required, waiting for second activation';
-    log.warn('Trip Switch (Knock): double-knock is required, waiting for second activation');
+    this._failureReason = 'Trip Switch (Knock): double-knock is required, waiting for second activation';
+    log.warn(this._failureReason);
     return true;
   }
 

--- a/src/conditions/double-knock-condition.ts
+++ b/src/conditions/double-knock-condition.ts
@@ -29,6 +29,7 @@ export class DoubleKnockCondition extends Condition {
   }
 
   evaluate({ state, options, value, origin, log }: ConditionContext): boolean {
+    this.clearFailureReason();
     if (!value || !options.doubleKnock) {
       return false;
     }

--- a/src/conditions/not-armed-condition.ts
+++ b/src/conditions/not-armed-condition.ts
@@ -21,6 +21,7 @@ export class NotArmedCondition extends Condition {
 
     const blocked = isDisarmed && isNotOverridingOff && isNotOverrideSwitch;
     if (blocked) {
+      this._failureReason = 'system is disarmed and override is not enabled';
       log.warn('Trip Switch (Not armed): system is disarmed and override is not enabled');
     }
     return blocked;

--- a/src/conditions/not-armed-condition.ts
+++ b/src/conditions/not-armed-condition.ts
@@ -21,8 +21,8 @@ export class NotArmedCondition extends Condition {
 
     const blocked = isDisarmed && isNotOverridingOff && isNotOverrideSwitch;
     if (blocked) {
-      this._failureReason = 'system is disarmed and override is not enabled';
-      log.warn('Trip Switch (Not armed): system is disarmed and override is not enabled');
+      this._failureReason = 'Trip Switch (Not armed): system is disarmed and override is not enabled';
+      log.warn(this._failureReason);
     }
     return blocked;
   }

--- a/src/conditions/not-armed-condition.ts
+++ b/src/conditions/not-armed-condition.ts
@@ -11,6 +11,7 @@ export class NotArmedCondition extends Condition {
   readonly name = 'not-armed';
 
   evaluate({ state, options, value, origin, log }: ConditionContext): boolean {
+    this.clearFailureReason();
     if (!value) {
       return false;
     }

--- a/src/conditions/trigger-already-running-condition.ts
+++ b/src/conditions/trigger-already-running-condition.ts
@@ -13,8 +13,8 @@ export class TriggerAlreadyRunningCondition extends Condition {
       return false;
     }
     if (state.isTripping) {
-      this._failureReason = 'trigger delay countdown is already running';
-      log.warn('Security System (Already tripped): trigger delay countdown is already running');
+      this._failureReason = 'Security System (Already tripped): trigger delay countdown is already running';
+      log.warn(this._failureReason);
       return true;
     }
     return false;

--- a/src/conditions/trigger-already-running-condition.ts
+++ b/src/conditions/trigger-already-running-condition.ts
@@ -9,6 +9,7 @@ export class TriggerAlreadyRunningCondition extends Condition {
   readonly name = 'trigger-already-running';
 
   evaluate({ state, value, log }: ConditionContext): boolean {
+    this.clearFailureReason();
     if (!value) {
       return false;
     }

--- a/src/conditions/trigger-already-running-condition.ts
+++ b/src/conditions/trigger-already-running-condition.ts
@@ -13,6 +13,7 @@ export class TriggerAlreadyRunningCondition extends Condition {
       return false;
     }
     if (state.isTripping) {
+      this._failureReason = 'trigger delay countdown is already running';
       log.warn('Security System (Already tripped): trigger delay countdown is already running');
       return true;
     }

--- a/src/handlers/state-handler.ts
+++ b/src/handlers/state-handler.ts
@@ -14,6 +14,7 @@ import type { AudioService } from '../services/audio-service.js';
 import type { SensorHandler } from './sensor-handler.js';
 import type { TimerManager } from '../timers/timer-manager.js';
 import { getArmingSeconds } from '../utils/arming-util.js';
+import type { ServiceResult } from '../types/service-result-type.js';
 
 /**
  * Manages the core security-system state machine: arming, triggering, and resetting.
@@ -56,9 +57,10 @@ export class StateHandler {
     this.storageService.save(this.state);
   }
 
-  updateTargetState(state: SecurityState, origin: OriginType, delay: number): boolean {
-    if (this.isBadTargetState(state)) {
-      return false;
+  updateTargetState(state: SecurityState, origin: OriginType, delay: number): ServiceResult {
+    const reason = this.getBadTargetStateReason(state);
+    if (reason !== null) {
+      return { success: false, reason };
     }
 
     this.state.targetState = state;
@@ -75,14 +77,14 @@ export class StateHandler {
 
     if (state === this.state.currentState) {
       this.setCurrentState(state, origin);
-      return false;
+      return { success: true };
     }
 
     const armSeconds = delay > 0 ? delay : 0;
 
     if (armSeconds === 0) {
       this.setCurrentState(state, origin);
-      return false;
+      return { success: true };
     }
 
     this.state.isArming = true;
@@ -94,7 +96,7 @@ export class StateHandler {
       this.setCurrentState(state, origin);
     });
 
-    return true;
+    return { success: true };
   }
 
   getArmingSeconds(targetState: SecurityState): number {
@@ -141,27 +143,31 @@ export class StateHandler {
 
   // ── Private helpers ────────────────────────────────────────────────────────
 
-  private isBadTargetState(state: SecurityState): boolean {
+  /**
+   * Returns a human-readable reason string if `state` is an invalid target,
+   * or `null` if the transition is permitted.
+   */
+  private getBadTargetStateReason(state: SecurityState): string | null {
     const isTriggered = this.state.currentState === SecurityState.TRIGGERED;
     const alreadySet = this.state.targetState === state;
 
     if (alreadySet && !isTriggered) {
       this.log.warn('Target mode (Already set)');
-      return true;
+      return 'target mode is already set';
     }
 
     if (!this.state.availableTargetStates.includes(state)) {
       this.log.warn('Target mode (Disabled)');
-      return true;
+      return 'target mode is disabled';
     }
 
     const hasLock = this.options.armingLockSwitch || this.options.armingLockSwitches;
     if (state !== SecurityState.OFF && hasLock && this.isArmingLocked(state)) {
       this.log.warn('Arming lock (Not allowed)');
-      return true;
+      return 'arming is blocked by an arming lock switch';
     }
 
-    return false;
+    return null;
   }
 
   private handleTargetStateChange(origin: OriginType): void {

--- a/src/handlers/switch-handler.ts
+++ b/src/handlers/switch-handler.ts
@@ -11,6 +11,7 @@ import { capitalise } from '../utils/state-util.js';
 import type { TimerManager } from '../timers/timer-manager.js';
 import type { EventBusService } from '../services/event-bus-service.js';
 import { EventType } from '../types/event-type.js';
+import type { ServiceResult } from '../types/service-result-type.js';
 
 /**
  * Handles all mode switches and the pause/extended switches.
@@ -98,7 +99,7 @@ export class SwitchHandler {
 
   // ── Arming lock switches ───────────────────────────────────────────────────
 
-  updateArmingLock(mode: string, value: boolean): boolean {
+  updateArmingLock(mode: string, value: boolean): ServiceResult {
     this.logArmingLock(mode, value);
 
     const map: Record<string, SingleServiceKey> = {
@@ -111,11 +112,11 @@ export class SwitchHandler {
     const key = map[mode];
     if (!key) {
       this.log.debug(`Unknown arming lock mode (${mode})`);
-      return false;
+      return { success: false, reason: `unknown arming lock mode: ${mode}` };
     }
 
     this.services[key].getCharacteristic(this.Characteristic.On).updateValue(value);
-    return true;
+    return { success: true };
   }
 
   // ── Mode switch display ────────────────────────────────────────────────────

--- a/src/handlers/trip-handler.ts
+++ b/src/handlers/trip-handler.ts
@@ -17,6 +17,7 @@ import { AlreadyTriggeredCondition } from '../conditions/already-triggered-condi
 import { DoubleKnockCondition } from '../conditions/double-knock-condition.js';
 import { TriggerAlreadyRunningCondition } from '../conditions/trigger-already-running-condition.js';
 import type { TimerManager } from '../timers/timer-manager.js';
+import type { ServiceResult } from '../types/service-result-type.js';
 
 /**
  * Handles the trip switch and trigger-delay logic, including all blocking conditions.
@@ -56,24 +57,33 @@ export class TripHandler {
   }
 
   /**
-   * Core trip-switch logic shared by all trip/trigger paths.
-   * Returns `true` on success, `false` if blocked.
+   * Evaluates all blocking conditions for a trip action without side effects.
+   * Returns a failed result with the condition's reason if any condition blocks the action.
    */
-  updateTripSwitch(value: boolean, origin: OriginType, stateChanged: boolean): boolean {
-    const ctx: ConditionContext = {
-      state: this.state,
-      services: this.services,
-      options: this.options,
-      value,
-      origin,
-      log: this.log,
-    };
+  checkTripConditions(value: boolean, origin: OriginType): ServiceResult {
+    if (!value) {
+      return { success: true };
+    }
 
+    const ctx = this.makeContext(value, origin);
+    for (const condition of this.conditions) {
+      if (condition.evaluate(ctx)) {
+        return { success: false, reason: condition.failureReason };
+      }
+    }
+
+    return { success: true };
+  }
+
+  /**
+   * Core trip-switch logic shared by all trip/trigger paths.
+   * Returns a result object indicating success or the reason for failure.
+   */
+  updateTripSwitch(value: boolean, origin: OriginType, stateChanged: boolean): ServiceResult {
     if (value) {
-      for (const condition of this.conditions) {
-        if (condition.evaluate(ctx)) {
-          return false;
-        }
+      const conditionResult = this.checkTripConditions(value, origin);
+      if (!conditionResult.success) {
+        return conditionResult;
       }
 
       this.activateTrip(origin);
@@ -86,14 +96,14 @@ export class TripHandler {
       this.services.tripSwitchService.updateCharacteristic(this.Characteristic.On, value);
     }
 
-    return true;
+    return { success: true };
   }
 
   /**
    * Trip a mode-specific switch. Only triggers if the system is currently in
    * the required mode (or the alarm is triggered and target matches).
    */
-  triggerIfModeSet(requiredState: SecurityState, value: boolean): boolean {
+  triggerIfModeSet(requiredState: SecurityState, value: boolean): ServiceResult {
     const isTriggered = this.state.currentState === SecurityState.TRIGGERED;
 
     if (value) {
@@ -102,7 +112,7 @@ export class TripHandler {
 
       if (!modeMatches) {
         this.log.debug('Security System (Trip mode not set)');
-        return false;
+        return { success: false, reason: 'mode not set' };
       }
     }
 
@@ -139,6 +149,17 @@ export class TripHandler {
         }
       }
     }
+  }
+
+  private makeContext(value: boolean, origin: OriginType): ConditionContext {
+    return {
+      state: this.state,
+      services: this.services,
+      options: this.options,
+      value,
+      origin,
+      log: this.log,
+    };
   }
 
   private activateTrip(origin: OriginType): void {

--- a/src/homekit/homekit-registrar.ts
+++ b/src/homekit/homekit-registrar.ts
@@ -39,6 +39,7 @@ export class HomeKitRegistrar {
     const tripSetHandler = (v: CharacteristicValue, origin: OriginType) => {
       const result = this.tripHandler.updateTripSwitch(v as boolean, origin, false);
       if (!result.success) {
+        this.log.debug(result.reason ?? 'Trip blocked');
         throw new this.api.hap.HapStatusError(HK_ERR as HAPStatus);
       }
     };
@@ -63,6 +64,7 @@ export class HomeKitRegistrar {
           this.log.info(`${label} Switch (${v ? 'On' : 'Off'})`);
           const result = this.tripHandler.triggerIfModeSet(mode, v as boolean);
           if (!result.success) {
+            this.log.debug(result.reason ?? 'Trip blocked');
             throw new this.api.hap.HapStatusError(HK_ERR as HAPStatus);
           }
         });
@@ -82,6 +84,7 @@ export class HomeKitRegistrar {
             this.log.info(`${name} Switch (${v ? 'On' : 'Off'})`);
             const result = this.tripHandler.triggerIfModeSet(mode, v as boolean);
             if (!result.success) {
+              this.log.debug(result.reason ?? 'Trip blocked');
               throw new this.api.hap.HapStatusError(HK_ERR as HAPStatus);
             }
           });

--- a/src/homekit/homekit-registrar.ts
+++ b/src/homekit/homekit-registrar.ts
@@ -37,8 +37,8 @@ export class HomeKitRegistrar {
 
     // Trip switches.
     const tripSetHandler = (v: CharacteristicValue, origin: OriginType) => {
-      const ok = this.tripHandler.updateTripSwitch(v as boolean, origin, false);
-      if (!ok) {
+      const result = this.tripHandler.updateTripSwitch(v as boolean, origin, false);
+      if (!result.success) {
         throw new this.api.hap.HapStatusError(HK_ERR as HAPStatus);
       }
     };
@@ -61,8 +61,8 @@ export class HomeKitRegistrar {
         .onGet(async () => Boolean(svc.getCharacteristic(Char.On).value))
         .onSet(async (v: CharacteristicValue) => {
           this.log.info(`${label} Switch (${v ? 'On' : 'Off'})`);
-          const ok = this.tripHandler.triggerIfModeSet(mode, v as boolean);
-          if (!ok) {
+          const result = this.tripHandler.triggerIfModeSet(mode, v as boolean);
+          if (!result.success) {
             throw new this.api.hap.HapStatusError(HK_ERR as HAPStatus);
           }
         });
@@ -80,8 +80,8 @@ export class HomeKitRegistrar {
           .onGet(async () => Boolean(svc.getCharacteristic(Char.On).value))
           .onSet(async (v: CharacteristicValue) => {
             this.log.info(`${name} Switch (${v ? 'On' : 'Off'})`);
-            const ok = this.tripHandler.triggerIfModeSet(mode, v as boolean);
-            if (!ok) {
+            const result = this.tripHandler.triggerIfModeSet(mode, v as boolean);
+            if (!result.success) {
               throw new this.api.hap.HapStatusError(HK_ERR as HAPStatus);
             }
           });

--- a/src/schemas/mode-request-schema.ts
+++ b/src/schemas/mode-request-schema.ts
@@ -11,8 +11,8 @@ export const ModeRequestSchema = z
       .nonnegative()
       .optional()
       .openapi({
-        example: 5000,
-        description: 'Optional delay in milliseconds before applying the mode change',
+        example: 5,
+        description: 'Optional delay in seconds before applying the mode change',
       }),
   })
   .openapi('ModeRequest');

--- a/src/services/server-service.ts
+++ b/src/services/server-service.ts
@@ -15,6 +15,7 @@ import { ErrorSchema } from '../schemas/error-schema.js';
 import { StatusResponseSchema } from '../schemas/status-response-schema.js';
 import { ModeRequestSchema } from '../schemas/mode-request-schema.js';
 import { ArmingLockRequestSchema } from '../schemas/arming-lock-schema.js';
+import type { ServiceResult } from '../types/service-result-type.js';
 
 const MODE_TO_STATE: Record<string, SecurityState> = {
   home: SecurityState.HOME,
@@ -188,24 +189,23 @@ export class ServerService {
     this.application.use('/mode', auth);
     this.application.openapi(modeRoute, (c) => {
       const { mode, delay = 0 } = c.req.valid('json');
-      let success: boolean;
+      let result: ServiceResult;
 
       if (mode === 'triggered') {
         if (delay > 0) {
-          success = this.tripHandler.updateTripSwitch(true, OriginType.EXTERNAL, false);
+          result = this.tripHandler.updateTripSwitch(true, OriginType.EXTERNAL, false);
         } else {
-          if (this.state.currentState === SecurityState.OFF && !this.options.overrideOff) {
-            return c.json({ reason: 'Cannot trigger alarm while system is disarmed' }, 409);
+          result = this.tripHandler.checkTripConditions(true, OriginType.EXTERNAL);
+          if (result.success) {
+            this.stateHandler.setCurrentState(SecurityState.TRIGGERED, OriginType.EXTERNAL);
           }
-          this.stateHandler.setCurrentState(SecurityState.TRIGGERED, OriginType.EXTERNAL);
-          success = true;
         }
       } else {
-        success = this.stateHandler.updateTargetState(MODE_TO_STATE[mode], OriginType.EXTERNAL, delay);
+        result = this.stateHandler.updateTargetState(MODE_TO_STATE[mode], OriginType.EXTERNAL, delay);
       }
 
-      if (!success) {
-        return c.json({ reason: 'Mode change rejected by the system' }, 409);
+      if (!result.success) {
+        return c.json({ reason: result.reason ?? 'Mode change rejected by the system' }, 409);
       }
 
       return c.body(null, 204);
@@ -215,10 +215,10 @@ export class ServerService {
     this.application.use('/switches/arming-lock', auth);
     this.application.openapi(armingLockRoute, (c) => {
       const { mode, value } = c.req.valid('json');
-      const success = this.switchHandler.updateArmingLock(mode, value);
+      const result = this.switchHandler.updateArmingLock(mode, value);
 
-      if (!success) {
-        return c.json({ reason: 'Arming lock update rejected by the system' }, 409);
+      if (!result.success) {
+        return c.json({ reason: result.reason ?? 'Arming lock update rejected by the system' }, 409);
       }
 
       return c.body(null, 204);

--- a/src/services/server-service.ts
+++ b/src/services/server-service.ts
@@ -37,15 +37,14 @@ const AUTH_RESPONSES = {
 
 const statusRoute = createRoute({
   method: 'get',
-  path: '/status',
-  summary: 'Get system status',
-  description:
-    'Returns the current arming state, active mode, target mode, and trip status of the security system.',
+  path: '/state',
+  summary: 'Get state',
+  description: 'Returns the current arming state, active mode, target mode, and trip status.',
   security: [{ BearerAuth: [] }],
   responses: {
     200: {
       content: { 'application/json': { schema: StatusResponseSchema } },
-      description: 'Current system status',
+      description: 'Current system state',
     },
     ...AUTH_RESPONSES,
   },
@@ -57,14 +56,14 @@ const modeRoute = createRoute({
   summary: 'Change security mode',
   description:
     'Sets the target security mode. Supported modes: home, away, night, off, triggered. ' +
-    'Use "triggered" to activate the alarm. An optional delay (ms) defers the transition.',
+    'Use "triggered" to activate the alarm. An optional delay (seconds) defers the transition.',
   security: [{ BearerAuth: [] }],
   request: {
     body: {
       content: {
         'application/json': {
           schema: ModeRequestSchema,
-          example: { mode: 'home', delay: 5000 },
+          example: { mode: 'home', delay: 5 },
         },
       },
       required: true,
@@ -174,8 +173,8 @@ export class ServerService {
       },
     });
 
-    // GET /status
-    this.application.use('/status', auth);
+    // GET /state
+    this.application.use('/state', auth);
     this.application.openapi(statusRoute, (c) => {
       return c.json({
         arming: this.state.isArming,

--- a/src/tests/state-handler.test.ts
+++ b/src/tests/state-handler.test.ts
@@ -167,7 +167,7 @@ describe('StateHandler.updateTargetState', async () => {
   const { StateHandler } = await import('../handlers/state-handler.js');
   const { EventBusService } = await import('../services/event-bus-service.js');
 
-  it('returns false when target state is already set (not triggered)', async () => {
+  it('returns failure when target state is already set (not triggered)', async () => {
     const state = makeState({ currentState: SecurityState.HOME, targetState: SecurityState.HOME });
     const log = makeMockLog();
     const bus = new EventBusService();
@@ -177,7 +177,8 @@ describe('StateHandler.updateTargetState', async () => {
     const handler = new StateHandler(makeServices(), state, makeOptions(), {} as any, log as any, bus, makeStorage(), makeAudio(), makeTimers(), sensor);
 
     const result = handler.updateTargetState(SecurityState.HOME, OriginType.INTERNAL, 0);
-    expect(result).toBe(false);
+    expect(result.success).toBe(false);
+    expect(result.reason).toBe('target mode is already set');
     expect(log.warn).toHaveBeenCalledWith('Target mode (Already set)');
   });
 
@@ -191,8 +192,7 @@ describe('StateHandler.updateTargetState', async () => {
     const handler = new StateHandler(makeServices(), state, makeOptions(), {} as any, log as any, bus, makeStorage(), makeAudio(), makeTimers(), sensor);
 
     const result = handler.updateTargetState(SecurityState.HOME, OriginType.REGULAR_SWITCH, 0);
-    // armSeconds=0 → synchronous transition; function returns false after setCurrentState
-    expect(result).toBe(false);
+    expect(result.success).toBe(true);
     expect(state.targetState).toBe(SecurityState.HOME);
   });
 });

--- a/src/tests/trip-handler.test.ts
+++ b/src/tests/trip-handler.test.ts
@@ -120,32 +120,36 @@ describe('TripHandler', async () => {
   it('blocks trip when system is disarmed (not overriding)', () => {
     state.currentState = SecurityState.OFF;
     const result = tripHandler.updateTripSwitch(true, OriginType.REGULAR_SWITCH, false);
-    expect(result).toBe(false);
+    expect(result.success).toBe(false);
+    expect(result.reason).toBe('system is disarmed and override is not enabled');
   });
 
   it('blocks trip when arming is in progress', () => {
     state.isArming = true;
     const result = tripHandler.updateTripSwitch(true, OriginType.REGULAR_SWITCH, false);
-    expect(result).toBe(false);
+    expect(result.success).toBe(false);
+    expect(result.reason).toBe('arm delay countdown is still in progress');
   });
 
   it('blocks trip when already triggered', () => {
     state.currentState = SecurityState.TRIGGERED;
     const result = tripHandler.updateTripSwitch(true, OriginType.REGULAR_SWITCH, false);
-    expect(result).toBe(false);
+    expect(result.success).toBe(false);
+    expect(result.reason).toBe('alarm is already active');
   });
 
   it('blocks trip when trigger timeout is already running', () => {
     state.isTripping = true;
     const result = tripHandler.updateTripSwitch(true, OriginType.REGULAR_SWITCH, false);
-    expect(result).toBe(false);
+    expect(result.success).toBe(false);
+    expect(result.reason).toBe('trigger delay countdown is already running');
     state.isTripping = false;
   });
 
   it('allows trip when system is armed (HOME mode)', () => {
     state.currentState = SecurityState.HOME;
     const result = tripHandler.updateTripSwitch(true, OriginType.REGULAR_SWITCH, false);
-    expect(result).toBe(true);
+    expect(result.success).toBe(true);
   });
 
   it('cancels trip and stops audio', () => {
@@ -189,13 +193,14 @@ describe('TripHandler', async () => {
   it('triggerIfModeSet allows when current mode matches required', () => {
     state.currentState = SecurityState.HOME;
     const result = tripHandler.triggerIfModeSet(SecurityState.HOME, true);
-    expect(result).toBe(true);
+    expect(result.success).toBe(true);
   });
 
   it('triggerIfModeSet blocks when current mode does not match', () => {
     state.currentState = SecurityState.AWAY;
     const result = tripHandler.triggerIfModeSet(SecurityState.HOME, true);
-    expect(result).toBe(false);
+    expect(result.success).toBe(false);
+    expect(result.reason).toBe('mode not set');
   });
 
   // ── Custom trip switch tests ───────────────────────────────────────────────
@@ -204,49 +209,49 @@ describe('TripHandler', async () => {
     it('custom HOME trip switch triggers only in HOME mode', () => {
       state.currentState = SecurityState.HOME;
       const result = tripHandler.triggerIfModeSet(SecurityState.HOME, true);
-      expect(result).toBe(true);
+      expect(result.success).toBe(true);
     });
 
     it('custom HOME trip switch blocks when not in HOME mode', () => {
       state.currentState = SecurityState.AWAY;
       const result = tripHandler.triggerIfModeSet(SecurityState.HOME, true);
-      expect(result).toBe(false);
+      expect(result.success).toBe(false);
     });
 
     it('custom AWAY trip switch triggers only in AWAY mode', () => {
       state.currentState = SecurityState.AWAY;
       const result = tripHandler.triggerIfModeSet(SecurityState.AWAY, true);
-      expect(result).toBe(true);
+      expect(result.success).toBe(true);
     });
 
     it('custom AWAY trip switch blocks when not in AWAY mode', () => {
       state.currentState = SecurityState.HOME;
       const result = tripHandler.triggerIfModeSet(SecurityState.AWAY, true);
-      expect(result).toBe(false);
+      expect(result.success).toBe(false);
     });
 
     it('custom NIGHT trip switch triggers only in NIGHT mode', () => {
       state.currentState = SecurityState.NIGHT;
       const result = tripHandler.triggerIfModeSet(SecurityState.NIGHT, true);
-      expect(result).toBe(true);
+      expect(result.success).toBe(true);
     });
 
     it('custom NIGHT trip switch blocks when not in NIGHT mode', () => {
       state.currentState = SecurityState.HOME;
       const result = tripHandler.triggerIfModeSet(SecurityState.NIGHT, true);
-      expect(result).toBe(false);
+      expect(result.success).toBe(false);
     });
 
     it('custom trip switch blocks when alarm is already triggered', () => {
       state.currentState = SecurityState.TRIGGERED;
       const result = tripHandler.triggerIfModeSet(SecurityState.HOME, true);
-      expect(result).toBe(false);
+      expect(result.success).toBe(false);
     });
 
     it('custom trip switch cancellation works with triggerIfModeSet', () => {
       state.currentState = SecurityState.HOME;
       const result = tripHandler.triggerIfModeSet(SecurityState.HOME, false);
-      expect(result).toBe(true);
+      expect(result.success).toBe(true);
       expect(mockAudio.stop).toHaveBeenCalled();
     });
 

--- a/src/tests/trip-handler.test.ts
+++ b/src/tests/trip-handler.test.ts
@@ -121,28 +121,28 @@ describe('TripHandler', async () => {
     state.currentState = SecurityState.OFF;
     const result = tripHandler.updateTripSwitch(true, OriginType.REGULAR_SWITCH, false);
     expect(result.success).toBe(false);
-    expect(result.reason).toBe('system is disarmed and override is not enabled');
+    expect(result.reason).toBe('Trip Switch (Not armed): system is disarmed and override is not enabled');
   });
 
   it('blocks trip when arming is in progress', () => {
     state.isArming = true;
     const result = tripHandler.updateTripSwitch(true, OriginType.REGULAR_SWITCH, false);
     expect(result.success).toBe(false);
-    expect(result.reason).toBe('arm delay countdown is still in progress');
+    expect(result.reason).toBe('Trip Switch (Still arming): arm delay countdown is still in progress');
   });
 
   it('blocks trip when already triggered', () => {
     state.currentState = SecurityState.TRIGGERED;
     const result = tripHandler.updateTripSwitch(true, OriginType.REGULAR_SWITCH, false);
     expect(result.success).toBe(false);
-    expect(result.reason).toBe('alarm is already active');
+    expect(result.reason).toBe('Security System (Already triggered): alarm is already active');
   });
 
   it('blocks trip when trigger timeout is already running', () => {
     state.isTripping = true;
     const result = tripHandler.updateTripSwitch(true, OriginType.REGULAR_SWITCH, false);
     expect(result.success).toBe(false);
-    expect(result.reason).toBe('trigger delay countdown is already running');
+    expect(result.reason).toBe('Security System (Already tripped): trigger delay countdown is already running');
     state.isTripping = false;
   });
 

--- a/src/types/service-result-type.ts
+++ b/src/types/service-result-type.ts
@@ -1,0 +1,4 @@
+export interface ServiceResult {
+  success: boolean;
+  reason?: string;
+}

--- a/src/types/service-result-type.ts
+++ b/src/types/service-result-type.ts
@@ -1,4 +1,4 @@
-export interface ServiceResult {
+export type ServiceResult = {
   success: boolean;
   reason?: string;
-}
+};


### PR DESCRIPTION
- Add ServiceResult interface { success, reason? } in src/types/service-result-type.ts
- Add _failureReason field and failureReason getter to Condition base class; each
  subclass sets _failureReason before returning true so callers can read why an
  action was blocked without re-evaluating the condition
- TripHandler: updateTripSwitch and triggerIfModeSet now return ServiceResult;
  extract condition evaluation into checkTripConditions for use in direct-trigger paths
- StateHandler: updateTargetState returns ServiceResult; rename isBadTargetState to
  getBadTargetStateReason returning string | null; immediate transitions now correctly
  return success: true instead of false (fixes a silent 409 bug in the server)
- SwitchHandler: updateArmingLock returns ServiceResult with a descriptive reason
- ServerService: replace the duplicated disarmed check with checkTripConditions and
  propagate condition.failureReason into 409 response bodies
- HomeKitRegistrar: use result.success instead of bare boolean
- Update all tests to assert on result.success and result.reason

https://claude.ai/code/session_01RW6ztAnagMjjpqBPcHSspo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced error reporting with detailed failure reasons when security operations are blocked.
  * State transitions, trip activation, and arming lock operations now provide specific explanations when they fail.
  * Users receive clearer error messages describing why requested changes cannot be completed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->