### PR TITLE
Separate trip endpoint from mode update endpoint

### DIFF
--- a/src/schemas/mode-request-schema.ts
+++ b/src/schemas/mode-request-schema.ts
@@ -3,8 +3,8 @@ import { z } from '@hono/zod-openapi';
 export const ModeRequestSchema = z
   .object({
     mode: z
-      .enum(['home', 'away', 'night', 'off', 'triggered'])
-      .openapi({ example: 'home', description: 'Target security mode to activate' }),
+      .enum(['home', 'away', 'night', 'off'])
+      .openapi({ example: 'home', description: 'Target mode to activate (home, away, night, or off)' }),
     delay: z
       .number()
       .int()

--- a/src/schemas/trip-mode-request-schema.ts
+++ b/src/schemas/trip-mode-request-schema.ts
@@ -1,0 +1,24 @@
+import { z } from '@hono/zod-openapi';
+
+export const TripModeRequestSchema = z
+  .object({
+    mode: z
+      .enum(['home', 'away', 'night'])
+      .nullable()
+      .optional()
+      .openapi({
+        example: 'home',
+        description: 'Mode to trip. If omitted or null, the action applies to all modes.',
+      }),
+    delay: z
+      .number()
+      .int()
+      .nonnegative()
+      .nullable()
+      .optional()
+      .openapi({
+        example: 5,
+        description: 'Delay in seconds before activating the alarm.',
+      }),
+  })
+  .openapi('TripModeRequest');

--- a/src/services/server-service.ts
+++ b/src/services/server-service.ts
@@ -14,6 +14,7 @@ import type { SwitchHandler } from '../handlers/switch-handler.js';
 import { ErrorSchema } from '../schemas/error-schema.js';
 import { StatusResponseSchema } from '../schemas/status-response-schema.js';
 import { ModeRequestSchema } from '../schemas/mode-request-schema.js';
+import { TripModeRequestSchema } from '../schemas/trip-mode-request-schema.js';
 import { ArmingLockRequestSchema } from '../schemas/arming-lock-schema.js';
 import type { ServiceResult } from '../types/service-result-type.js';
 
@@ -52,11 +53,12 @@ const statusRoute = createRoute({
 
 const modeRoute = createRoute({
   method: 'put',
-  path: '/mode',
-  summary: 'Change security mode',
+  path: '/mode/update',
+  summary: 'Change mode',
   description:
-    'Sets the target security mode. Supported modes: home, away, night, off, triggered. ' +
-    'Use "triggered" to activate the alarm. An optional delay (seconds) defers the transition.',
+    'Sets the target security mode. Supported modes: home, away, night, off. ' +
+    'An optional delay (seconds) defers the transition. ' +
+    'To trigger the alarm use the POST /mode/trip endpoint instead.',
   security: [{ BearerAuth: [] }],
   request: {
     body: {
@@ -79,10 +81,40 @@ const modeRoute = createRoute({
   },
 });
 
+const tripModeRoute = createRoute({
+  method: 'post',
+  path: '/mode/trip',
+  summary: 'Trip mode',
+  description:
+    'Activates the alarm ("triggered" state). ' +
+    'If mode is specified the alarm only fires when the system is currently in that mode. ' +
+    'An optional delay (seconds) defers the activation.',
+  security: [{ BearerAuth: [] }],
+  request: {
+    body: {
+      content: {
+        'application/json': {
+          schema: TripModeRequestSchema,
+          example: { mode: 'home', delay: 30 },
+        },
+      },
+      required: true,
+    },
+  },
+  responses: {
+    204: { description: 'Trip accepted' },
+    ...AUTH_RESPONSES,
+    409: {
+      content: { 'application/json': { schema: ErrorSchema } },
+      description: 'Trip rejected by the system',
+    },
+  },
+});
+
 const armingLockRoute = createRoute({
   method: 'put',
   path: '/switches/arming-lock',
-  summary: 'Update arming lock switch',
+  summary: 'Update arming lock',
   description: 'Enables or disables the arming lock for a specific mode or globally.',
   security: [{ BearerAuth: [] }],
   request: {
@@ -117,11 +149,16 @@ export class ServerService {
     private readonly stateHandler: StateHandler,
     private readonly tripHandler: TripHandler,
     private readonly switchHandler: SwitchHandler,
-  ) {}
+  ) {
+    this.registerRoutes();
+  }
+
+  /** Exposed for testing — returns the underlying Hono app. */
+  get app(): OpenAPIHono {
+    return this.application;
+  }
 
   start(): void {
-    this.registerRoutes();
-
     const server = serve(
       { fetch: this.application.fetch, port: this.options.serverPort! },
       () => this.log.info(`Server (${this.options.serverPort})`),
@@ -184,27 +221,52 @@ export class ServerService {
       });
     });
 
-    // PUT /mode
-    this.application.use('/mode', auth);
+    // PUT /mode/update
+    this.application.use('/mode/update', auth);
     this.application.openapi(modeRoute, (c) => {
       const { mode, delay = 0 } = c.req.valid('json');
-      let result: ServiceResult;
-
-      if (mode === 'triggered') {
-        if (delay > 0) {
-          result = this.tripHandler.updateTripSwitch(true, OriginType.EXTERNAL, false);
-        } else {
-          result = this.tripHandler.checkTripConditions(true, OriginType.EXTERNAL);
-          if (result.success) {
-            this.stateHandler.setCurrentState(SecurityState.TRIGGERED, OriginType.EXTERNAL);
-          }
-        }
-      } else {
-        result = this.stateHandler.updateTargetState(MODE_TO_STATE[mode], OriginType.EXTERNAL, delay);
-      }
+      const result = this.stateHandler.updateTargetState(MODE_TO_STATE[mode], OriginType.EXTERNAL, delay);
 
       if (!result.success) {
         return c.json({ reason: result.reason ?? 'Mode change rejected by the system' }, 409);
+      }
+
+      return c.body(null, 204);
+    });
+
+    // POST /mode/trip
+    this.application.use('/mode/trip', auth);
+    this.application.openapi(tripModeRoute, (c) => {
+      const { mode, delay } = c.req.valid('json');
+      const effectiveDelay = delay ?? 0;
+
+      if (effectiveDelay > 0) {
+        const precheck = this.tripHandler.checkTripConditions(true, OriginType.EXTERNAL);
+        if (!precheck.success) {
+          return c.json({ reason: precheck.reason ?? 'Trip rejected by the system' }, 409);
+        }
+
+        setTimeout(() => {
+          if (mode != null) {
+            this.tripHandler.triggerIfModeSet(MODE_TO_STATE[mode], true);
+          } else {
+            this.tripHandler.updateTripSwitch(true, OriginType.EXTERNAL, false);
+          }
+        }, effectiveDelay * 1000);
+
+        return c.body(null, 204);
+      }
+
+      let result: ServiceResult;
+
+      if (mode != null) {
+        result = this.tripHandler.triggerIfModeSet(MODE_TO_STATE[mode], true);
+      } else {
+        result = this.tripHandler.updateTripSwitch(true, OriginType.EXTERNAL, false);
+      }
+
+      if (!result.success) {
+        return c.json({ reason: result.reason ?? 'Trip rejected by the system' }, 409);
       }
 
       return c.body(null, 204);

--- a/src/tests/server-service.test.ts
+++ b/src/tests/server-service.test.ts
@@ -1,0 +1,238 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { SecurityState } from '../types/security-state-type.js';
+import { OriginType } from '../types/origin-type.js';
+import type { SystemState } from '../interfaces/system-state-interface.js';
+import type { SecuritySystemOptions } from '../interfaces/options-interface.js';
+import type { ServiceResult } from '../types/service-result-type.js';
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeLog() {
+  return { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() };
+}
+
+function makeState(overrides: Partial<SystemState> = {}): SystemState {
+  return {
+    currentState: SecurityState.OFF,
+    targetState: SecurityState.OFF,
+    defaultState: SecurityState.OFF,
+    availableTargetStates: [SecurityState.HOME, SecurityState.AWAY, SecurityState.NIGHT, SecurityState.OFF],
+    isArming: false,
+    isTripping: false,
+    isKnocked: false,
+    serverAuthenticationAttempts: 0,
+    pausedCurrentState: null,
+    audioProcess: null,
+    ...overrides,
+  };
+}
+
+function makeOptions(overrides: Partial<SecuritySystemOptions> = {}): SecuritySystemOptions {
+  return {
+    serverPort: 8080,
+    serverApiKey: null,
+    ...overrides,
+  } as unknown as SecuritySystemOptions;
+}
+
+function makeStateHandler(result: ServiceResult = { success: true }) {
+  return {
+    updateTargetState: vi.fn().mockReturnValue(result),
+    isTripping: vi.fn().mockReturnValue(false),
+    setCurrentState: vi.fn(),
+  };
+}
+
+function makeTripHandler(result: ServiceResult = { success: true }) {
+  return {
+    updateTripSwitch: vi.fn().mockReturnValue(result),
+    triggerIfModeSet: vi.fn().mockReturnValue(result),
+    checkTripConditions: vi.fn().mockReturnValue(result),
+  };
+}
+
+function makeSwitchHandler(result: ServiceResult = { success: true }) {
+  return {
+    updateArmingLock: vi.fn().mockReturnValue(result),
+  };
+}
+
+async function makeService(
+  stateHandlerResult?: ServiceResult,
+  tripHandlerResult?: ServiceResult,
+  switchHandlerResult?: ServiceResult,
+  stateOverrides?: Partial<SystemState>,
+  optionsOverrides?: Partial<SecuritySystemOptions>,
+) {
+  const { ServerService } = await import('../services/server-service.js');
+  const log = makeLog();
+  const state = makeState(stateOverrides);
+  const options = makeOptions(optionsOverrides);
+  const stateHandler = makeStateHandler(stateHandlerResult);
+  const tripHandler = makeTripHandler(tripHandlerResult);
+  const switchHandler = makeSwitchHandler(switchHandlerResult);
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const service = new ServerService(log as any, options, state, stateHandler as any, tripHandler as any, switchHandler as any);
+
+  return { service, stateHandler, tripHandler, switchHandler, state };
+}
+
+function json(body: unknown, path: string, method = 'PUT') {
+  return new Request(`http://localhost${path}`, {
+    method,
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+// ── PUT /mode/update ──────────────────────────────────────────────────────────
+
+describe('PUT /mode/update', () => {
+  it('returns 204 and calls updateTargetState with no delay', async () => {
+    const { service, stateHandler } = await makeService();
+    const res = await service.app.request(json({ mode: 'home' }, '/mode/update'));
+    expect(res.status).toBe(204);
+    expect(stateHandler.updateTargetState).toHaveBeenCalledWith(SecurityState.HOME, OriginType.EXTERNAL, 0);
+  });
+
+  it('returns 204 and passes delay to updateTargetState', async () => {
+    const { service, stateHandler } = await makeService();
+    const res = await service.app.request(json({ mode: 'away', delay: 10 }, '/mode/update'));
+    expect(res.status).toBe(204);
+    expect(stateHandler.updateTargetState).toHaveBeenCalledWith(SecurityState.AWAY, OriginType.EXTERNAL, 10);
+  });
+
+  it('returns 204 for off mode without delay', async () => {
+    const { service, stateHandler } = await makeService();
+    const res = await service.app.request(json({ mode: 'off' }, '/mode/update'));
+    expect(res.status).toBe(204);
+    expect(stateHandler.updateTargetState).toHaveBeenCalledWith(SecurityState.OFF, OriginType.EXTERNAL, 0);
+  });
+
+  it('returns 409 when stateHandler rejects the mode change', async () => {
+    const { service } = await makeService({ success: false, reason: 'target mode is already set' });
+    const res = await service.app.request(json({ mode: 'night' }, '/mode/update'));
+    expect(res.status).toBe(409);
+    const body = await res.json();
+    expect(body.reason).toBe('target mode is already set');
+  });
+
+  it('rejects "triggered" — returns 400 (Zod validation failure)', async () => {
+    const { service } = await makeService();
+    const res = await service.app.request(json({ mode: 'triggered' }, '/mode/update'));
+    expect(res.status).toBe(400);
+  });
+});
+
+// ── POST /mode/trip ───────────────────────────────────────────────────────────
+
+describe('POST /mode/trip', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('returns 204 and calls updateTripSwitch when mode and delay are omitted', async () => {
+    const { service, tripHandler } = await makeService();
+    const res = await service.app.request(json({}, '/mode/trip', 'POST'));
+    expect(res.status).toBe(204);
+    expect(tripHandler.updateTripSwitch).toHaveBeenCalledWith(true, OriginType.EXTERNAL, false);
+    expect(tripHandler.triggerIfModeSet).not.toHaveBeenCalled();
+  });
+
+  it('returns 204 and calls updateTripSwitch when mode is null', async () => {
+    const { service, tripHandler } = await makeService();
+    const res = await service.app.request(json({ mode: null }, '/mode/trip', 'POST'));
+    expect(res.status).toBe(204);
+    expect(tripHandler.updateTripSwitch).toHaveBeenCalledWith(true, OriginType.EXTERNAL, false);
+  });
+
+  it('returns 204 and calls triggerIfModeSet when mode is specified', async () => {
+    const { service, tripHandler } = await makeService();
+    const res = await service.app.request(json({ mode: 'away' }, '/mode/trip', 'POST'));
+    expect(res.status).toBe(204);
+    expect(tripHandler.triggerIfModeSet).toHaveBeenCalledWith(SecurityState.AWAY, true);
+    expect(tripHandler.updateTripSwitch).not.toHaveBeenCalled();
+  });
+
+  it('returns 409 when trip handler rejects without delay', async () => {
+    const { service } = await makeService(undefined, { success: false, reason: 'not armed' });
+    const res = await service.app.request(json({}, '/mode/trip', 'POST'));
+    expect(res.status).toBe(409);
+    const body = await res.json();
+    expect(body.reason).toBe('not armed');
+  });
+
+  it('returns 409 when mode does not match (triggerIfModeSet rejects)', async () => {
+    const { service } = await makeService(undefined, { success: false, reason: 'mode not set' });
+    const res = await service.app.request(json({ mode: 'home' }, '/mode/trip', 'POST'));
+    expect(res.status).toBe(409);
+    const body = await res.json();
+    expect(body.reason).toBe('mode not set');
+  });
+
+  it('returns 204 immediately and calls updateTripSwitch after delay when mode is omitted', async () => {
+    vi.useFakeTimers();
+    const { service, tripHandler } = await makeService();
+
+    const res = await service.app.request(json({ delay: 5 }, '/mode/trip', 'POST'));
+    expect(res.status).toBe(204);
+    expect(tripHandler.checkTripConditions).toHaveBeenCalledWith(true, OriginType.EXTERNAL);
+    expect(tripHandler.updateTripSwitch).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(5000);
+    expect(tripHandler.updateTripSwitch).toHaveBeenCalledWith(true, OriginType.EXTERNAL, false);
+  });
+
+  it('returns 204 immediately and calls triggerIfModeSet after delay when mode is specified', async () => {
+    vi.useFakeTimers();
+    const { service, tripHandler } = await makeService();
+
+    const res = await service.app.request(json({ mode: 'night', delay: 3 }, '/mode/trip', 'POST'));
+    expect(res.status).toBe(204);
+    expect(tripHandler.triggerIfModeSet).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(3000);
+    expect(tripHandler.triggerIfModeSet).toHaveBeenCalledWith(SecurityState.NIGHT, true);
+  });
+
+  it('returns 409 on pre-check failure even when delay is specified', async () => {
+    const { service, tripHandler } = await makeService(
+      undefined,
+      { success: false, reason: 'arming in progress' },
+    );
+    const res = await service.app.request(json({ delay: 10 }, '/mode/trip', 'POST'));
+    expect(res.status).toBe(409);
+    expect(tripHandler.updateTripSwitch).not.toHaveBeenCalled();
+  });
+
+  it('treats delay: null the same as no delay', async () => {
+    const { service, tripHandler } = await makeService();
+    const res = await service.app.request(json({ delay: null }, '/mode/trip', 'POST'));
+    expect(res.status).toBe(204);
+    expect(tripHandler.updateTripSwitch).toHaveBeenCalledWith(true, OriginType.EXTERNAL, false);
+  });
+});
+
+// ── PUT /switches/arming-lock ─────────────────────────────────────────────────
+
+describe('PUT /switches/arming-lock', () => {
+  it('returns 204 and calls updateArmingLock', async () => {
+    const { service, switchHandler } = await makeService();
+    const res = await service.app.request(json({ mode: 'home', value: true }, '/switches/arming-lock'));
+    expect(res.status).toBe(204);
+    expect(switchHandler.updateArmingLock).toHaveBeenCalledWith('home', true);
+  });
+
+  it('returns 409 when switchHandler rejects', async () => {
+    const { service } = await makeService(
+      undefined,
+      undefined,
+      { success: false, reason: 'unknown arming lock mode: invalid' },
+    );
+    const res = await service.app.request(json({ mode: 'global', value: false }, '/switches/arming-lock'));
+    expect(res.status).toBe(409);
+    const body = await res.json();
+    expect(body.reason).toBe('unknown arming lock mode: invalid');
+  });
+});


### PR DESCRIPTION
## Summary
Refactored the security system API to separate alarm triggering functionality into its own dedicated endpoint. Previously, the `PUT /mode` endpoint handled both mode changes and alarm triggering (via the "triggered" mode). This change splits these concerns into two distinct endpoints for better API clarity and separation of concerns.

## Key Changes
- **New endpoint**: `POST /mode/trip` - Dedicated endpoint for activating the alarm ("triggered" state)
  - Supports optional `mode` parameter to only trigger if system is in a specific mode
  - Supports optional `delay` parameter (in seconds) to defer activation
  - Includes pre-check validation when delay is specified
  
- **Updated endpoint**: `PUT /mode/update` (formerly `PUT /mode`)
  - Now only handles mode transitions (home, away, night, off)
  - Removed "triggered" mode from supported values
  - Updated documentation to reference the new trip endpoint
  
- **New schema**: `TripModeRequestSchema` - Validates trip requests with optional mode and delay parameters

- **Implementation details**:
  - Trip requests with delay use `checkTripConditions` for pre-validation before scheduling
  - Mode-specific trips use `triggerIfModeSet` to ensure alarm only fires in the specified mode
  - Generic trips use `updateTripSwitch` when no mode is specified
  - Immediate trips (no delay) validate conditions synchronously
  - Delayed trips return 204 immediately and execute asynchronously

## Testing
Added comprehensive test suite (`server-service.test.ts`) covering:
- Mode update endpoint with various delay scenarios
- Trip endpoint with and without mode specification
- Trip endpoint with delayed activation
- Error handling for both endpoints (409 conflicts, 400 validation failures)
- Arming lock switch endpoint

https://claude.ai/code/session_01FG8KxyEjmNGQDiF45BVyfT

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dedicated trip activation endpoint with optional delay parameter for scheduled mode switching.

* **Changes**
  * Removed "triggered" mode option from standard mode requests; mode now accepts only home, away, night, and off states.
  * Reorganized mode control endpoints for improved separation of concerns between standard updates and trip-based operations.

* **Tests**
  * Added comprehensive test coverage for mode control endpoints and trip activation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->