### PR TITLE
Add lint step to build workflow and improve PR trigger conditions

### DIFF
--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -7,13 +7,14 @@ on:
     paths-ignore:
       - "**.md"
   pull_request:
-    types: [opened, reopened, synchronize, ready_for_review]
+    types: [opened, reopened, synchronize, ready_for_review, labeled, unlabeled]
     paths-ignore:
       - "**.md"
 
 jobs:
   build-package:
     name: Build package
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'ignore-for-release') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -35,6 +36,7 @@ jobs:
       - name: Build package
         run: |
           npm ci
+          npm run lint
           npm pack
 
       - name: Attest build provenance

--- a/src/tests/server-service.test.ts
+++ b/src/tests/server-service.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 import { SecurityState } from '../types/security-state-type.js';
 import { OriginType } from '../types/origin-type.js';
 import type { SystemState } from '../interfaces/system-state-interface.js';


### PR DESCRIPTION
## Summary
This PR enhances the CI/CD pipeline with linting validation and improves workflow trigger conditions to better manage release workflows.

## Key Changes
- **Workflow improvements:**
  - Added `labeled` and `unlabeled` events to pull request triggers for better workflow control
  - Added conditional check to skip build job when `ignore-for-release` label is present
  - Added `npm run lint` step to the build process to catch code quality issues early

- **Test cleanup:**
  - Removed unused `beforeEach` import from `server-service.test.ts`

## Implementation Details
The build job now includes a linting step that runs before packaging, ensuring code quality standards are met. The new label-based conditional allows developers to skip the build workflow for PRs that shouldn't trigger releases, providing more granular control over the CI/CD pipeline.

https://claude.ai/code/session_01WN1xSSvnYwVukAhQsGN7s5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Integrated code linting verification into the build pipeline, running before package creation to maintain consistent code quality standards across releases
  * Extended build workflow to respond to pull request label events, enabling improved release management with conditional build execution when specific labels are applied

* **Tests**
  * Streamlined test file module imports to reduce unnecessary dependencies

<!-- end of auto-generated comment: release notes by coderabbit.ai -->