### PR TITLE
fix: make PUT /mode/update idempotent for same-target re-calls

### DIFF
--- a/src/handlers/state-handler.ts
+++ b/src/handlers/state-handler.ts
@@ -58,6 +58,21 @@ export class StateHandler {
   }
 
   updateTargetState(state: SecurityState, origin: OriginType, delay: number): ServiceResult {
+    // Same-target re-call: "confirm this mode externally; apply it now"
+    if (state === this.state.targetState && this.state.currentState !== SecurityState.TRIGGERED) {
+      if (state === this.state.currentState) {
+        return { success: true };
+      }
+
+      if (this.state.isArming) {
+        this.timers.clearArmTimer();
+        this.state.isArming = false;
+      }
+
+      this.setCurrentState(state, origin);
+      return { success: true };
+    }
+
     const reason = this.getBadTargetStateReason(state);
     if (reason !== null) {
       return { success: false, reason };

--- a/src/tests/state-handler.test.ts
+++ b/src/tests/state-handler.test.ts
@@ -167,19 +167,52 @@ describe('StateHandler.updateTargetState', async () => {
   const { StateHandler } = await import('../handlers/state-handler.js');
   const { EventBusService } = await import('../services/event-bus-service.js');
 
-  it('returns failure when target state is already set (not triggered)', async () => {
+  it('returns success (no-op) when currentState already matches the requested mode', async () => {
     const state = makeState({ currentState: SecurityState.HOME, targetState: SecurityState.HOME });
     const log = makeMockLog();
     const bus = new EventBusService();
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const sensor = makeMockSensor() as any;
+    const timers = makeTimers();
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const handler = new StateHandler(makeServices(), state, makeOptions(), {} as any, log as any, bus, makeStorage(), makeAudio(), makeTimers(), sensor);
+    const handler = new StateHandler(makeServices(), state, makeOptions(), {} as any, log as any, bus, makeStorage(), makeAudio(), timers, sensor);
 
     const result = handler.updateTargetState(SecurityState.HOME, OriginType.INTERNAL, 0);
-    expect(result.success).toBe(false);
-    expect(result.reason).toBe('target mode is already set');
-    expect(log.warn).toHaveBeenCalledWith('Target mode (Already set)');
+    expect(result.success).toBe(true);
+    expect(timers.clearArmTimer).not.toHaveBeenCalled();
+  });
+
+  it('cancels arm timer and applies state immediately on same-target re-call while arming', async () => {
+    const state = makeState({ currentState: SecurityState.OFF, targetState: SecurityState.HOME, isArming: true });
+    const log = makeMockLog();
+    const bus = new EventBusService();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const sensor = makeMockSensor() as any;
+    const timers = makeTimers();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const handler = new StateHandler(makeServices(), state, makeOptions(), {} as any, log as any, bus, makeStorage(), makeAudio(), timers, sensor);
+
+    const result = handler.updateTargetState(SecurityState.HOME, OriginType.EXTERNAL, 0);
+    expect(result.success).toBe(true);
+    expect(timers.clearArmTimer).toHaveBeenCalled();
+    expect(state.isArming).toBe(false);
+    expect(state.currentState).toBe(SecurityState.HOME);
+  });
+
+  it('applies state immediately on same-target re-call when not arming', async () => {
+    const state = makeState({ currentState: SecurityState.OFF, targetState: SecurityState.HOME, isArming: false });
+    const log = makeMockLog();
+    const bus = new EventBusService();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const sensor = makeMockSensor() as any;
+    const timers = makeTimers();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const handler = new StateHandler(makeServices(), state, makeOptions(), {} as any, log as any, bus, makeStorage(), makeAudio(), timers, sensor);
+
+    const result = handler.updateTargetState(SecurityState.HOME, OriginType.EXTERNAL, 0);
+    expect(result.success).toBe(true);
+    expect(timers.clearArmTimer).not.toHaveBeenCalled();
+    expect(state.currentState).toBe(SecurityState.HOME);
   });
 
   it('transitions to a new armed mode', async () => {


### PR DESCRIPTION
When the requested mode matches the current target:
- currentState == mode → 204 no-op (already fully applied)
- isArming == true → cancel arm timer + apply state immediately → 204
- otherwise → apply state immediately → 204

Semantically, calling with the same mode again means "I confirm this
mode externally; apply it now", replacing the previous 409 rejection.

https://claude.ai/code/session_01R7Gsy2Y8kJ1KN6s9iwjcaR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed behavior when requesting a target state that is already set; the system now processes the request successfully instead of rejecting it.
  * When a state transition is in progress, requesting the same target state now completes it immediately.

* **Tests**
  * Expanded test coverage for state request scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->