### PR TITLE
feat: add optional event-driven MQTT publish

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -690,6 +690,38 @@
         "type": "string",
         "required": false,
         "placeholder": "echo current triggered"
+      },
+      "mqtt_broker": {
+        "title": "MQTT Broker URL",
+        "description": "",
+        "type": "string",
+        "required": false,
+        "placeholder": "mqtt://localhost:1883"
+      },
+      "mqtt_username": {
+        "title": "MQTT Username",
+        "description": "",
+        "type": "string",
+        "required": false
+      },
+      "mqtt_password": {
+        "title": "MQTT Password",
+        "description": "",
+        "type": "string",
+        "required": false
+      },
+      "mqtt_topic": {
+        "title": "MQTT Topic",
+        "description": "",
+        "type": "string",
+        "default": "security-system/state",
+        "required": false
+      },
+      "mqtt_client_id": {
+        "title": "MQTT Client ID",
+        "description": "",
+        "type": "string",
+        "required": false
       }
     }
   },
@@ -929,6 +961,20 @@
         "command_current_off",
         "command_current_warning",
         "command_current_triggered"
+      ]
+    },
+    {
+      "type": "fieldset",
+      "title": "MQTT",
+      "description": "Publish state updates to an MQTT broker.",
+      "expandable": true,
+      "expanded": false,
+      "items": [
+        "mqtt_broker",
+        "mqtt_username",
+        "mqtt_password",
+        "mqtt_topic",
+        "mqtt_client_id"
       ]
     }
   ]

--- a/docs/MQTT.md
+++ b/docs/MQTT.md
@@ -1,0 +1,50 @@
+# MQTT
+
+Publish real-time security system state updates to an MQTT broker.
+
+## Configuration
+
+Add these fields to your plugin config (or configure via the Homebridge UI):
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `mqtt_broker` | `string` | — | Broker URL, e.g. `mqtt://localhost:1883` or `mqtts://broker.example.com:8883` |
+| `mqtt_username` | `string` | — | Optional username for authentication |
+| `mqtt_password` | `string` | — | Optional password for authentication |
+| `mqtt_topic` | `string` | `security-system/state` | Topic to publish status payloads to |
+| `mqtt_client_id` | `string` | — | Optional client ID (auto-generated if omitted) |
+
+MQTT is **optional** — omit `mqtt_broker` to disable it.
+
+## Payload
+
+Published as a retained JSON message on every state change:
+
+```json
+{
+  "arming": false,
+  "current_mode": "home",
+  "target_mode": "home",
+  "tripped": true
+}
+```
+
+| Field | Type | Description |
+|---|---|---|
+| `arming` | `boolean` | Whether the system is counting down an arming delay |
+| `current_mode` | `string` | Current active mode: `off`, `home`, `away`, `night`, `triggered` |
+| `target_mode` | `string` | Target mode being transitioned to |
+| `tripped` | `boolean` | Whether a trip switch is active (trigger delay counting down) |
+
+## Events
+
+Publishes are triggered by these state machine changes:
+
+- Current mode changes (`CURRENT_CHANGED`)
+- Target mode changes (`TARGET_CHANGED`)
+- Arming delay start (`ARMING`)
+- Warning state (`WARNING`)
+
+## Proxy Mode
+
+If `proxy_mode` is enabled, publishes originating from external sources (e.g. HTTP API) are suppressed.

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "@hono/zod-openapi": "^1.3.0",
         "@scalar/hono-api-reference": "^0.10.9",
         "hono": "^4.12.14",
+        "mqtt": "^5.15.1",
         "node-persist": "^4.0.1",
         "zod": "^4.3.6"
       },
@@ -50,6 +51,15 @@
       },
       "peerDependencies": {
         "zod": "^4.0.0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@cspotcode/source-map-support": {
@@ -1015,7 +1025,6 @@
       "version": "25.6.2",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.2.tgz",
       "integrity": "sha512-sokuT28dxf9JT5Kady1fsXOvI4HVpjZa95NKT5y9PNTIrs2AsobR4GFAA90ZG8M+nxVRLysCXsVj6eGC7Vbrlw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.19.0"
@@ -1026,6 +1035,24 @@
       "resolved": "https://registry.npmjs.org/@types/node-persist/-/node-persist-3.1.8.tgz",
       "integrity": "sha512-QLidg6/SadZYPrTKxtxL1A85XBoQlG40bhoMdhu6DH6+eNCMr2j+RGfFZ9I9+IY8W/PDwQonJ+iBWD62jZjMfg==",
       "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/readable-stream": {
+      "version": "4.0.23",
+      "resolved": "https://registry.npmjs.org/@types/readable-stream/-/readable-stream-4.0.23.tgz",
+      "integrity": "sha512-wwXrtQvbMHxCbBgjHaMGEmImFTQxxpfMOR/ZoQnXxB1woqkUbdLGFDgauo00Py9IudiaqSeiBiulSV9i6XIPig==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -1374,6 +1401,18 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "license": "MIT",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -1468,6 +1507,26 @@
         "node": "18 || 20 || >=22"
       }
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -1479,6 +1538,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/bl": {
+      "version": "6.1.6",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-6.1.6.tgz",
+      "integrity": "sha512-jLsPgN/YSvPUg9UX0Kd73CXpm2Psg9FxMeCSXnk3WBO3CMT10JMwijubhGfHCnFu6TPn1ei3b975dxv7K2pWVg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/readable-stream": "^4.0.0",
+        "buffer": "^6.0.3",
+        "inherits": "^2.0.4",
+        "readable-stream": "^4.2.0"
       }
     },
     "node_modules/bonjour-hap": {
@@ -1519,11 +1590,46 @@
         "node": ">=8"
       }
     },
+    "node_modules/broker-factory": {
+      "version": "3.1.14",
+      "resolved": "https://registry.npmjs.org/broker-factory/-/broker-factory-3.1.14.tgz",
+      "integrity": "sha512-L45k5HMbPIrMid0nTOZ/UPXG/c0aRuQKVrSDFIb1zOkvfiyHgYmIjc3cSiN1KwQIvRDOtKE0tfb3I9EZ3CmpQQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.2",
+        "fast-unique-numbers": "^9.0.27",
+        "tslib": "^2.8.1",
+        "worker-factory": "^7.0.49"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
     "node_modules/buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/chai": {
@@ -1584,6 +1690,41 @@
         "node": ">=20"
       }
     },
+    "node_modules/commist": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/commist/-/commist-3.2.0.tgz",
+      "integrity": "sha512-4PIMoPniho+LqXmpS5d3NuGYncG6XWlkBSVGiWycL22dd42OYdUGil2CWuzklaJoNxyxUSpO4MKIBU94viWNAw==",
+      "license": "MIT"
+    },
+    "node_modules/concat-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
+      "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
+      "engines": [
+        "node >= 6.0"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.0.2",
+        "typedarray": "^0.0.6"
+      }
+    },
+    "node_modules/concat-stream/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -1617,7 +1758,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -1876,6 +2016,24 @@
         "through": "^2.3.8"
       }
     },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
     "node_modules/expect-type": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
@@ -1915,6 +2073,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=10.17.0"
+      }
+    },
+    "node_modules/fast-unique-numbers": {
+      "version": "9.0.27",
+      "resolved": "https://registry.npmjs.org/fast-unique-numbers/-/fast-unique-numbers-9.0.27.tgz",
+      "integrity": "sha512-nDA9ADeINN8SA2u2wCtU+siWFTTDqQR37XvgPIDDmboWQeExz7X0mImxuaN+kJddliIqy2FpVRmnvRZ+j8i1/A==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.2",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=18.2.0"
       }
     },
     "node_modules/file-entry-cache": {
@@ -2066,6 +2237,12 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/help-me": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/help-me/-/help-me-5.0.0.tgz",
+      "integrity": "sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==",
+      "license": "MIT"
+    },
     "node_modules/hexy": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/hexy/-/hexy-0.4.0.tgz",
@@ -2124,6 +2301,26 @@
         "node": ">=16.9.0"
       }
     },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -2149,6 +2346,21 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/is-binary-path": {
@@ -2203,6 +2415,16 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/js-sdsl": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.3.0.tgz",
+      "integrity": "sha512-mifzlm2+5nZ+lEcLJMoBK0/IH/bDg8XnJfd/Wq6IP+xoCjLZsTOnV2QpxlVbX9bMnkl5PdEjNtBJ9Cj1NjifhQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/js-sdsl"
+      }
     },
     "node_modules/json-buffer": {
       "version": "3.0.1",
@@ -2600,7 +2822,6 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -2629,11 +2850,59 @@
         "mkdirp": "bin/cmd.js"
       }
     },
+    "node_modules/mqtt": {
+      "version": "5.15.1",
+      "resolved": "https://registry.npmjs.org/mqtt/-/mqtt-5.15.1.tgz",
+      "integrity": "sha512-V1WnkGuJh3ec9QXzy5Iylw8OOBK+Xu1WhxcQ9mMpLThG+/JZIMV1PgLNRgIiqXhZnvnVLsuyxHl5A/3bHHbcAA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/readable-stream": "^4.0.21",
+        "@types/ws": "^8.18.1",
+        "commist": "^3.2.0",
+        "concat-stream": "^2.0.0",
+        "debug": "^4.4.1",
+        "help-me": "^5.0.0",
+        "lru-cache": "^10.4.3",
+        "minimist": "^1.2.8",
+        "mqtt-packet": "^9.0.2",
+        "number-allocator": "^1.0.14",
+        "readable-stream": "^4.7.0",
+        "rfdc": "^1.4.1",
+        "socks": "^2.8.6",
+        "split2": "^4.2.0",
+        "worker-timers": "^8.0.23",
+        "ws": "^8.18.3"
+      },
+      "bin": {
+        "mqtt": "build/bin/mqtt.js",
+        "mqtt_pub": "build/bin/pub.js",
+        "mqtt_sub": "build/bin/sub.js"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/mqtt-packet": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/mqtt-packet/-/mqtt-packet-9.0.2.tgz",
+      "integrity": "sha512-MvIY0B8/qjq7bKxdN1eD+nrljoeaai+qjLJgfRn3TiMuz0pamsIWY2bFODPZMSNmabsLANXsLl4EMoWvlaTZWA==",
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^6.0.8",
+        "debug": "^4.3.4",
+        "process-nextick-args": "^2.0.1"
+      }
+    },
+    "node_modules/mqtt/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "license": "ISC"
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/multicast-dns": {
@@ -2755,6 +3024,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/number-allocator": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/number-allocator/-/number-allocator-1.0.14.tgz",
+      "integrity": "sha512-OrL44UTVAvkKdOdRQZIJpLkAdjXGTRda052sN4sO77bKEzYYqWKMBjQvrJFzqygI99gL6Z4u2xctPW1tB8ErvA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.1",
+        "js-sdsl": "4.3.0"
       }
     },
     "node_modules/obug": {
@@ -2949,6 +3228,21 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "license": "MIT"
+    },
     "node_modules/pstree.remy": {
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/pstree.remy/-/pstree.remy-1.1.8.tgz",
@@ -2987,6 +3281,22 @@
         "qrcode-terminal": "bin/qrcode-terminal.js"
       }
     },
+    "node_modules/readable-stream": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+      "license": "MIT",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
     "node_modules/readdirp": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
@@ -2999,6 +3309,12 @@
       "engines": {
         "node": ">=8.10.0"
       }
+    },
+    "node_modules/rfdc": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
+      "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
+      "license": "MIT"
     },
     "node_modules/rimraf": {
       "version": "6.1.3",
@@ -3058,7 +3374,6 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -3141,6 +3456,30 @@
         "node": ">=10"
       }
     },
+    "node_modules/smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks": {
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.9.tgz",
+      "integrity": "sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.1.1",
+        "smart-buffer": "^4.2.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
     "node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -3185,6 +3524,15 @@
         "node": "*"
       }
     },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
     "node_modules/stackback": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
@@ -3208,6 +3556,15 @@
       "dependencies": {
         "duplexer": "~0.1.1",
         "through": "~2.3.4"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
       }
     },
     "node_modules/tagged-tag": {
@@ -3395,7 +3752,6 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
       "license": "0BSD"
     },
     "node_modules/tweetnacl": {
@@ -3432,6 +3788,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
+      "license": "MIT"
     },
     "node_modules/typescript": {
       "version": "6.0.3",
@@ -3482,7 +3844,6 @@
       "version": "7.19.2",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
       "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/universalify": {
@@ -3504,6 +3865,12 @@
       "dependencies": {
         "punycode": "^2.1.0"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
     },
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",
@@ -3747,6 +4114,74 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/worker-factory": {
+      "version": "7.0.49",
+      "resolved": "https://registry.npmjs.org/worker-factory/-/worker-factory-7.0.49.tgz",
+      "integrity": "sha512-lW7tpgy6aUv2dFsQhv1yv+XFzdkCf/leoKRTGMPVK5/die6RrUjqgJHJf556qO+ZfytNG6wPXc17E8zzsOLUDw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.2",
+        "fast-unique-numbers": "^9.0.27",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/worker-timers": {
+      "version": "8.0.31",
+      "resolved": "https://registry.npmjs.org/worker-timers/-/worker-timers-8.0.31.tgz",
+      "integrity": "sha512-ngkq5S6JuZyztom8tDgBzorLo9byhBMko/sXfgiUD945AuzKGg1GCgDMCC3NaYkicLpGKXutONM36wEX8UbBCA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.2",
+        "tslib": "^2.8.1",
+        "worker-timers-broker": "^8.0.16",
+        "worker-timers-worker": "^9.0.14"
+      }
+    },
+    "node_modules/worker-timers-broker": {
+      "version": "8.0.16",
+      "resolved": "https://registry.npmjs.org/worker-timers-broker/-/worker-timers-broker-8.0.16.tgz",
+      "integrity": "sha512-JyP3AvUGyPGbBGW7XiUewm2+0pN/aYo1QpVf5kdXAfkDZcN3p7NbWrG6XnyDEpDIvfHk/+LCnOW/NsuiU9riYA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.2",
+        "broker-factory": "^3.1.14",
+        "fast-unique-numbers": "^9.0.27",
+        "tslib": "^2.8.1",
+        "worker-timers-worker": "^9.0.14"
+      }
+    },
+    "node_modules/worker-timers-worker": {
+      "version": "9.0.14",
+      "resolved": "https://registry.npmjs.org/worker-timers-worker/-/worker-timers-worker-9.0.14.tgz",
+      "integrity": "sha512-/qF06C60sXmSLfUl7WglvrDIbspmPOM8UrG63Dnn4bi2x4/DfqHS/+dxF5B+MdHnYO5tVuZYLHdAodrKdabTIg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.2",
+        "tslib": "^2.8.1",
+        "worker-factory": "^7.0.49"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/xml2js": {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@hono/zod-openapi": "^1.3.0",
     "@scalar/hono-api-reference": "^0.10.9",
     "hono": "^4.12.14",
+    "mqtt": "^5.15.1",
     "node-persist": "^4.0.1",
     "zod": "^4.3.6"
   },

--- a/src/constants/default-constant.ts
+++ b/src/constants/default-constant.ts
@@ -25,4 +25,7 @@ export const DEFAULTS = {
   MODE_AWAY_EXTENDED_SWITCH_NAME: 'Mode Away Extended',
   MODE_PAUSE_SWITCH_NAME: 'Mode Pause',
   AUDIO_SWITCH_NAME: 'Audio',
+
+  // MQTT
+  MQTT_TOPIC: 'security-system/state',
 } as const;

--- a/src/interfaces/mqtt-status-payload-interface.ts
+++ b/src/interfaces/mqtt-status-payload-interface.ts
@@ -1,0 +1,6 @@
+export interface MqttStatusPayload {
+  arming: boolean;
+  current_mode: string;
+  target_mode: string;
+  tripped: boolean;
+}

--- a/src/interfaces/options-interface.ts
+++ b/src/interfaces/options-interface.ts
@@ -127,4 +127,11 @@ export interface SecuritySystemOptions {
   webhookCurrentOff: string | null;
   webhookCurrentWarning: string | null;
   webhookCurrentTriggered: string | null;
+
+  // MQTT
+  mqttBroker: string | null;
+  mqttUsername: string | null;
+  mqttPassword: string | null;
+  mqttTopic: string;
+  mqttClientId: string | null;
 }

--- a/src/security-system.ts
+++ b/src/security-system.ts
@@ -14,6 +14,7 @@ import { StorageService } from './services/storage-service.js';
 import { AudioService } from './services/audio-service.js';
 import { WebhookService } from './services/webhook-service.js';
 import { CommandService } from './services/command-service.js';
+import { MqttService } from './services/mqtt-service.js';
 import { ServerService } from './services/server-service.js';
 import { StateHandler } from './handlers/state-handler.js';
 import { TripHandler } from './handlers/trip-handler.js';
@@ -101,6 +102,9 @@ export class SecuritySystem implements AccessoryPlugin {
     const commandSvc = new CommandService(log, this.options, this.state);
     webhookSvc.attachToBus(this.bus);
     commandSvc.attachToBus(this.bus);
+    const mqttSvc = new MqttService(log, this.options, this.state);
+    mqttSvc.attachToBus(this.bus);
+    this.api.on('shutdown', () => mqttSvc.disconnect());
 
     // Register HomeKit characteristic handlers.
     new HomeKitRegistrar(this.api, this.log, this.svcs, this.state, this.stateHandler, this.tripHandler, this.switchHandler)

--- a/src/services/configuration-service.ts
+++ b/src/services/configuration-service.ts
@@ -203,6 +203,13 @@ export class ConfigurationService {
       webhookCurrentOff: this.str(raw, 'webhook_current_off'),
       webhookCurrentWarning: this.str(raw, 'webhook_current_warning'),
       webhookCurrentTriggered: this.str(raw, 'webhook_current_triggered'),
+
+      // MQTT
+      mqttBroker: this.str(raw, 'mqtt_broker'),
+      mqttUsername: this.str(raw, 'mqtt_username'),
+      mqttPassword: this.str(raw, 'mqtt_password'),
+      mqttTopic: this.str(raw, 'mqtt_topic') ?? DEFAULTS.MQTT_TOPIC,
+      mqttClientId: this.str(raw, 'mqtt_client_id'),
     };
   }
 
@@ -216,6 +223,10 @@ export class ConfigurationService {
 
     if (opts.serverPort !== null && (opts.serverPort < 0 || opts.serverPort > 65535)) {
       this.log.error('\'server_port\' must be between 0 and 65535.');
+    }
+
+    if (opts.mqttBroker !== null && !/^mqtts?:\/\//.test(opts.mqttBroker)) {
+      this.log.warn('\'mqtt_broker\' should start with mqtt:// or mqtts://');
     }
   }
 

--- a/src/services/mqtt-service.ts
+++ b/src/services/mqtt-service.ts
@@ -1,0 +1,123 @@
+import { connect } from 'mqtt';
+import type { MqttClient } from 'mqtt';
+import type { Logging } from 'homebridge';
+import { stateToMode } from '../utils/state-util.js';
+import { OriginType } from '../types/origin-type.js';
+import type { SecuritySystemOptions } from '../interfaces/options-interface.js';
+import type { SystemState } from '../interfaces/system-state-interface.js';
+import type { MqttStatusPayload } from '../interfaces/mqtt-status-payload-interface.js';
+import type { EventBusService } from './event-bus-service.js';
+import { EventType } from '../types/event-type.js';
+import type { TargetChangedPayload, CurrentChangedPayload, WarningPayload } from '../types/event-type.js';
+
+export class MqttService {
+  private client: MqttClient | null = null;
+
+  constructor(
+    private readonly log: Logging,
+    private readonly options: SecuritySystemOptions,
+    private readonly state: SystemState,
+  ) {}
+
+  attachToBus(bus: EventBusService): void {
+    if (!this.options.mqttBroker) {
+      this.log.debug('MQTT broker not configured.');
+      return;
+    }
+
+    this.connect();
+
+    bus.on(EventType.TARGET_CHANGED, (payload: TargetChangedPayload) => {
+      this.publishStatus(payload.origin);
+    });
+    bus.on(EventType.CURRENT_CHANGED, (payload: CurrentChangedPayload) => {
+      this.publishStatus(payload.origin);
+    });
+    bus.on(EventType.ARMING, () => {
+      this.publishStatus(OriginType.INTERNAL);
+    });
+    bus.on(EventType.WARNING, (payload: WarningPayload) => {
+      this.publishStatus(payload.origin);
+    });
+  }
+
+  disconnect(): void {
+    if (this.client) {
+      this.client.end(true);
+      this.client = null;
+    }
+  }
+
+  private connect(): void {
+    const connectionOptions: Record<string, unknown> = {};
+
+    if (this.options.mqttClientId) {
+      connectionOptions.clientId = this.options.mqttClientId;
+    }
+
+    if (this.options.mqttUsername) {
+      connectionOptions.username = this.options.mqttUsername;
+    }
+
+    if (this.options.mqttPassword) {
+      connectionOptions.password = this.options.mqttPassword;
+    }
+
+    this.client = connect(this.options.mqttBroker!, connectionOptions);
+
+    this.client.on('connect', () => {
+      this.log.info(`MQTT (${this.sanitiseBrokerUrl()})`);
+    });
+
+    this.client.on('error', (error: Error) => {
+      this.log.error('MQTT error.');
+      this.log.error(String(error));
+    });
+
+    this.client.on('close', () => {
+      this.log.debug('MQTT connection closed.');
+    });
+  }
+
+  private publishStatus(origin: OriginType): void {
+    if (!this.client?.connected) {
+      return;
+    }
+
+    if (this.options.proxyMode && origin === OriginType.EXTERNAL) {
+      this.log.debug('MQTT publish bypassed (proxy mode).');
+      return;
+    }
+
+    const payload: MqttStatusPayload = {
+      arming: this.state.isArming,
+      current_mode: stateToMode(this.state.currentState),
+      target_mode: stateToMode(this.state.targetState),
+      tripped: this.state.isTripping,
+    };
+
+    this.client.publish(
+      this.options.mqttTopic,
+      JSON.stringify(payload),
+      { qos: 0, retain: true },
+      (error?: Error) => {
+        if (error) {
+          this.log.error(`MQTT publish failed (${this.options.mqttTopic})`);
+          this.log.error(String(error));
+        }
+      },
+    );
+  }
+
+  private sanitiseBrokerUrl(): string {
+    try {
+      const url = new URL(this.options.mqttBroker!);
+      if (url.password) {
+        url.password = '****';
+      }
+      return url.toString();
+    } catch {
+      return this.options.mqttBroker!;
+    }
+  }
+}

--- a/src/tests/mqtt-service.test.ts
+++ b/src/tests/mqtt-service.test.ts
@@ -1,0 +1,230 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { EventType } from '../types/event-type.js';
+import { OriginType } from '../types/origin-type.js';
+import { SecurityState } from '../types/security-state-type.js';
+import { EventBusService } from '../services/event-bus-service.js';
+import type { SystemState } from '../interfaces/system-state-interface.js';
+import type { SecuritySystemOptions } from '../interfaces/options-interface.js';
+import { MqttService } from '../services/mqtt-service.js';
+
+// ── Mocks ─────────────────────────────────────────────────────────────────────
+
+const mockClient = {
+  on: vi.fn().mockReturnThis(),
+  publish: vi.fn(),
+  connected: true,
+  end: vi.fn(),
+};
+
+vi.mock('mqtt', () => ({
+  connect: vi.fn(() => mockClient),
+}));
+
+import { connect } from 'mqtt';
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeLog() {
+  return { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() };
+}
+
+function makeState(overrides: Partial<SystemState> = {}): SystemState {
+  return {
+    currentState: SecurityState.OFF,
+    targetState: SecurityState.OFF,
+    defaultState: SecurityState.OFF,
+    availableTargetStates: [SecurityState.HOME, SecurityState.AWAY, SecurityState.NIGHT, SecurityState.OFF],
+    isArming: false,
+    isTripping: false,
+    isKnocked: false,
+    serverAuthenticationAttempts: 0,
+    pausedCurrentState: null,
+    audioProcess: null,
+    ...overrides,
+  };
+}
+
+function makeOptions(overrides: Partial<SecuritySystemOptions> = {}): SecuritySystemOptions {
+  return {
+    mqttBroker: null,
+    mqttUsername: null,
+    mqttPassword: null,
+    mqttTopic: 'security-system/state',
+    mqttClientId: null,
+    proxyMode: false,
+    ...overrides,
+  } as unknown as SecuritySystemOptions;
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────────
+
+describe('MqttService', () => {
+  let log: ReturnType<typeof makeLog>;
+  let state: SystemState;
+  let bus: EventBusService;
+
+  beforeEach(() => {
+    log = makeLog();
+    state = makeState();
+    bus = new EventBusService();
+    vi.clearAllMocks();
+    mockClient.connected = true;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('does nothing when broker is not configured', () => {
+    const service = new MqttService(log as never, makeOptions({ mqttBroker: null }), state);
+    service.attachToBus(bus);
+
+    expect(connect).not.toHaveBeenCalled();
+    expect(log.debug).toHaveBeenCalledWith('MQTT broker not configured.');
+  });
+
+  it('connects when broker is configured', () => {
+    const service = new MqttService(log as never, makeOptions({ mqttBroker: 'mqtt://localhost:1883' }), state);
+    service.attachToBus(bus);
+
+    expect(connect).toHaveBeenCalledWith('mqtt://localhost:1883', {});
+    expect(mockClient.on).toHaveBeenCalledWith('connect', expect.any(Function));
+    expect(mockClient.on).toHaveBeenCalledWith('error', expect.any(Function));
+    expect(mockClient.on).toHaveBeenCalledWith('close', expect.any(Function));
+  });
+
+  it('passes connection options when provided', () => {
+    const options = makeOptions({
+      mqttBroker: 'mqtt://broker:1883',
+      mqttUsername: 'user',
+      mqttPassword: 'pass',
+      mqttClientId: 'my-client',
+    });
+
+    new MqttService(log as never, options, state).attachToBus(bus);
+
+    expect(connect).toHaveBeenCalledWith('mqtt://broker:1883', {
+      clientId: 'my-client',
+      username: 'user',
+      password: 'pass',
+    });
+  });
+
+  it('publishes status on TARGET_CHANGED event', () => {
+    state.isArming = true;
+    state.currentState = SecurityState.HOME;
+    state.targetState = SecurityState.AWAY;
+
+    const service = new MqttService(log as never, makeOptions({ mqttBroker: 'mqtt://localhost' }), state);
+    service.attachToBus(bus);
+
+    bus.emit(EventType.TARGET_CHANGED, { state: SecurityState.AWAY, origin: OriginType.INTERNAL });
+
+    expect(mockClient.publish).toHaveBeenCalledWith(
+      'security-system/state',
+      JSON.stringify({
+        arming: true,
+        current_mode: 'home',
+        target_mode: 'away',
+        tripped: false,
+      }),
+      { qos: 0, retain: true },
+      expect.any(Function),
+    );
+  });
+
+  it('publishes status on CURRENT_CHANGED event', () => {
+    state.currentState = SecurityState.TRIGGERED;
+    state.isTripping = true;
+
+    const service = new MqttService(log as never, makeOptions({ mqttBroker: 'mqtt://localhost' }), state);
+    service.attachToBus(bus);
+
+    bus.emit(EventType.CURRENT_CHANGED, { state: SecurityState.TRIGGERED, origin: OriginType.INTERNAL });
+
+    expect(mockClient.publish).toHaveBeenCalledTimes(1);
+  });
+
+  it('publishes status on ARMING event', () => {
+    const service = new MqttService(log as never, makeOptions({ mqttBroker: 'mqtt://localhost' }), state);
+    service.attachToBus(bus);
+
+    bus.emit(EventType.ARMING, { state: SecurityState.HOME });
+
+    expect(mockClient.publish).toHaveBeenCalledTimes(1);
+  });
+
+  it('publishes status on WARNING event', () => {
+    const service = new MqttService(log as never, makeOptions({ mqttBroker: 'mqtt://localhost' }), state);
+    service.attachToBus(bus);
+
+    bus.emit(EventType.WARNING, { origin: OriginType.INTERNAL, triggerSeconds: 30 });
+
+    expect(mockClient.publish).toHaveBeenCalledTimes(1);
+  });
+
+  it('bypasses publish when proxyMode is on and origin is EXTERNAL', () => {
+    const service = new MqttService(log as never, makeOptions({ mqttBroker: 'mqtt://localhost', proxyMode: true }), state);
+    service.attachToBus(bus);
+
+    bus.emit(EventType.TARGET_CHANGED, { state: SecurityState.HOME, origin: OriginType.EXTERNAL });
+
+    expect(mockClient.publish).not.toHaveBeenCalled();
+    expect(log.debug).toHaveBeenCalledWith('MQTT publish bypassed (proxy mode).');
+  });
+
+  it('does not bypass publish when proxyMode is on but origin is INTERNAL', () => {
+    const service = new MqttService(log as never, makeOptions({ mqttBroker: 'mqtt://localhost', proxyMode: true }), state);
+    service.attachToBus(bus);
+
+    bus.emit(EventType.TARGET_CHANGED, { state: SecurityState.HOME, origin: OriginType.INTERNAL });
+
+    expect(mockClient.publish).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not publish when client is not connected', () => {
+    mockClient.connected = false;
+
+    const service = new MqttService(log as never, makeOptions({ mqttBroker: 'mqtt://localhost' }), state);
+    service.attachToBus(bus);
+
+    bus.emit(EventType.TARGET_CHANGED, { state: SecurityState.HOME, origin: OriginType.INTERNAL });
+
+    expect(mockClient.publish).not.toHaveBeenCalled();
+  });
+
+  it('disconnect ends the client', () => {
+    const service = new MqttService(log as never, makeOptions({ mqttBroker: 'mqtt://localhost' }), state);
+    service.attachToBus(bus);
+    service.disconnect();
+
+    expect(mockClient.end).toHaveBeenCalledWith(true);
+  });
+
+  it('uses custom topic when configured', () => {
+    const service = new MqttService(log as never, makeOptions({ mqttBroker: 'mqtt://localhost', mqttTopic: 'alarm/status' }), state);
+    service.attachToBus(bus);
+
+    bus.emit(EventType.CURRENT_CHANGED, { state: SecurityState.OFF, origin: OriginType.INTERNAL });
+
+    expect(mockClient.publish).toHaveBeenCalledWith(
+      'alarm/status',
+      expect.any(String),
+      expect.any(Object),
+      expect.any(Function),
+    );
+  });
+
+  it('logs error on publish failure', () => {
+    const service = new MqttService(log as never, makeOptions({ mqttBroker: 'mqtt://localhost' }), state);
+    service.attachToBus(bus);
+
+    bus.emit(EventType.CURRENT_CHANGED, { state: SecurityState.OFF, origin: OriginType.INTERNAL });
+
+    const publishCallback = mockClient.publish.mock.calls[0][3];
+    publishCallback(new Error('connection lost'));
+
+    expect(log.error).toHaveBeenCalledWith('MQTT publish failed (security-system/state)');
+    expect(log.error).toHaveBeenCalledWith('Error: connection lost');
+  });
+});


### PR DESCRIPTION
Adds an optional MQTT publish feature that emits state/status payloads on state machine events.

**Changes:**
- New \MqttService\ in \src/services/\ following existing event-driven pattern (\ttachToBus\)
- Payload matches the HTTP API shape: \{ arming, current_mode, target_mode, tripped }\
- Publishes with \etain: true\ so subscribers get latest state on connect
- Supports authentication (username/password), custom topic, client ID
- Respects \proxyMode\ setting
- Config schema fields and Homebridge UI layout added
- 13 tests covering all event types, proxy mode, disconnected guard, cleanup
- Documentation in \docs/MQTT.md\

Closes #849

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added optional MQTT integration to publish real-time security system state updates to a configured broker. Users can now configure broker URL, credentials, topic, and client ID through the plugin settings.

* **Documentation**
  * Added comprehensive MQTT configuration and integration documentation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MiguelRipoll23/homebridge-securitysystem/pull/851?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->