### PR TITLE
fix: reset global trip switch when system is disarmed

### DIFF
--- a/src/handlers/trip-handler.ts
+++ b/src/handlers/trip-handler.ts
@@ -121,6 +121,7 @@ export class TripHandler {
 
   resetTripSwitches(): void {
     const switches: Array<[SingleServiceKey, string]> = [
+      ['tripSwitchService', 'Trip'],
       ['tripHomeSwitchService', 'Trip Home'],
       ['tripAwaySwitchService', 'Trip Away'],
       ['tripNightSwitchService', 'Trip Night'],

--- a/src/tests/trip-handler.test.ts
+++ b/src/tests/trip-handler.test.ts
@@ -203,6 +203,46 @@ describe('TripHandler', async () => {
     expect(result.reason).toBe('mode not set');
   });
 
+  // ── resetTripSwitches tests ────────────────────────────────────────────────
+
+  describe('resetTripSwitches', () => {
+    it('resets global trip switch', () => {
+      const globalChar = services.tripSwitchService.getCharacteristic();
+      globalChar.value = true;
+
+      tripHandler.resetTripSwitches();
+
+      expect(globalChar.updateValue).toHaveBeenCalledWith(false);
+    });
+
+    it('resets mode-specific trip switches', () => {
+      const homeChar = services.tripHomeSwitchService.getCharacteristic();
+      const awayChar = services.tripAwaySwitchService.getCharacteristic();
+      const nightChar = services.tripNightSwitchService.getCharacteristic();
+      const overrideChar = services.tripOverrideSwitchService.getCharacteristic();
+      homeChar.value = true;
+      awayChar.value = true;
+      nightChar.value = true;
+      overrideChar.value = true;
+
+      tripHandler.resetTripSwitches();
+
+      expect(homeChar.updateValue).toHaveBeenCalledWith(false);
+      expect(awayChar.updateValue).toHaveBeenCalledWith(false);
+      expect(nightChar.updateValue).toHaveBeenCalledWith(false);
+      expect(overrideChar.updateValue).toHaveBeenCalledWith(false);
+    });
+
+    it('does not touch switches that are already off', () => {
+      const globalChar = services.tripSwitchService.getCharacteristic();
+      globalChar.value = false;
+
+      tripHandler.resetTripSwitches();
+
+      expect(globalChar.updateValue).not.toHaveBeenCalled();
+    });
+  });
+
   // ── Custom trip switch tests ───────────────────────────────────────────────
 
   describe('Custom Trip Switches', () => {


### PR DESCRIPTION
Closes #859

The global trip switch was not included in \esetTripSwitches()\, so it stayed on when the system was disarmed while all mode-specific trip switches correctly turned off.

**Changes:**
- Add \	ripSwitchService\ to the reset list in \esetTripSwitches()\
- Add regression tests verifying global and mode-specific trip switches are reset

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Trip reset now turns off the global trip switch characteristic alongside mode-specific switches.

* **Tests**
  * Added test coverage to verify trip switch reset functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->