### PR TITLE
fix: add missing argument to getCharacteristic calls and run tsc in CI

### DIFF
--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -37,6 +37,7 @@ jobs:
         run: |
           npm ci
           npm run lint
+          npm run build
           npm pack
 
       - name: Attest build provenance

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -32,4 +32,10 @@ export default tseslint.config(
   },
   eslint.configs.recommended,
   ...tseslint.configs.recommended,
+  {
+    files: ['src/tests/**/*.ts'],
+    rules: {
+      '@typescript-eslint/no-explicit-any': 'off',
+    },
+  },
 );

--- a/src/tests/server-service.test.ts
+++ b/src/tests/server-service.test.ts
@@ -72,7 +72,6 @@ async function makeService(
   const tripHandler = makeTripHandler(tripHandlerResult);
   const switchHandler = makeSwitchHandler(switchHandlerResult);
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const service = new ServerService(log as any, options, state, stateHandler as any, tripHandler as any, switchHandler as any);
 
   return { service, stateHandler, tripHandler, switchHandler, state };

--- a/src/tests/state-handler.test.ts
+++ b/src/tests/state-handler.test.ts
@@ -109,7 +109,6 @@ function makeTimers() {
     setTrippedInterval: vi.fn(), clearTrippedInterval: vi.fn(),
     setTriggeredInterval: vi.fn(), clearTriggeredInterval: vi.fn(),
     clearAll: vi.fn(),
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
   } as any;
 }
 
@@ -139,9 +138,7 @@ describe('StateHandler.getArmingSeconds', async () => {
     const log = makeMockLog();
     const bus = new EventBusService();
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const sensor = makeMockSensor() as any;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     stateHandler = new StateHandler(services, state, options, {} as any, log as any, bus, makeStorage(), makeAudio(), makeTimers(), sensor);
   });
 
@@ -171,10 +168,8 @@ describe('StateHandler.updateTargetState', async () => {
     const state = makeState({ currentState: SecurityState.HOME, targetState: SecurityState.HOME });
     const log = makeMockLog();
     const bus = new EventBusService();
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const sensor = makeMockSensor() as any;
     const timers = makeTimers();
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const handler = new StateHandler(makeServices(), state, makeOptions(), {} as any, log as any, bus, makeStorage(), makeAudio(), timers, sensor);
 
     const result = handler.updateTargetState(SecurityState.HOME, OriginType.INTERNAL, 0);
@@ -186,10 +181,8 @@ describe('StateHandler.updateTargetState', async () => {
     const state = makeState({ currentState: SecurityState.OFF, targetState: SecurityState.HOME, isArming: true });
     const log = makeMockLog();
     const bus = new EventBusService();
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const sensor = makeMockSensor() as any;
     const timers = makeTimers();
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const handler = new StateHandler(makeServices(), state, makeOptions(), {} as any, log as any, bus, makeStorage(), makeAudio(), timers, sensor);
 
     const result = handler.updateTargetState(SecurityState.HOME, OriginType.EXTERNAL, 0);
@@ -203,10 +196,8 @@ describe('StateHandler.updateTargetState', async () => {
     const state = makeState({ currentState: SecurityState.OFF, targetState: SecurityState.HOME, isArming: false });
     const log = makeMockLog();
     const bus = new EventBusService();
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const sensor = makeMockSensor() as any;
     const timers = makeTimers();
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const handler = new StateHandler(makeServices(), state, makeOptions(), {} as any, log as any, bus, makeStorage(), makeAudio(), timers, sensor);
 
     const result = handler.updateTargetState(SecurityState.HOME, OriginType.EXTERNAL, 0);
@@ -219,9 +210,7 @@ describe('StateHandler.updateTargetState', async () => {
     const state = makeState({ currentState: SecurityState.OFF, targetState: SecurityState.OFF });
     const log = makeMockLog();
     const bus = new EventBusService();
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const sensor = makeMockSensor() as any;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const handler = new StateHandler(makeServices(), state, makeOptions(), {} as any, log as any, bus, makeStorage(), makeAudio(), makeTimers(), sensor);
 
     const result = handler.updateTargetState(SecurityState.HOME, OriginType.REGULAR_SWITCH, 0);

--- a/src/tests/trip-handler.test.ts
+++ b/src/tests/trip-handler.test.ts
@@ -92,7 +92,6 @@ describe('TripHandler', async () => {
   let state: SystemState;
   let services: ServiceRegistry;
   let bus: InstanceType<typeof EventBusService>;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   let tripHandler: any;
   const mockSensorHandler = {
     pulseTrippedMotionSensor: vi.fn(),
@@ -104,7 +103,6 @@ describe('TripHandler', async () => {
     setTrippedInterval: vi.fn(), clearTrippedInterval: vi.fn(),
     setDoubleKnockTimer: vi.fn(), clearDoubleKnockTimer: vi.fn(),
     clearAll: vi.fn(),
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
   } as any;
 
   beforeEach(() => {
@@ -113,7 +111,6 @@ describe('TripHandler', async () => {
     services = makeServices();
     bus = new EventBusService();
     const mockLog = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() };
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     tripHandler = new TripHandler(services, state, makeOptions(), {} as any, mockLog as any, bus, mockAudio as any, mockSensorHandler as any, mockTimers);
   });
 
@@ -164,7 +161,6 @@ describe('TripHandler', async () => {
 
   it('emits TRIP_CANCELLED with stateChanged=false when trip cancelled while triggered', () => {
     state.currentState = SecurityState.TRIGGERED;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     let payload: any;
     bus.on(EventType.TRIP_CANCELLED, (p) => {
       payload = p;
@@ -178,7 +174,6 @@ describe('TripHandler', async () => {
 
   it('emits TRIP_CANCELLED with stateChanged=true when state has changed', () => {
     state.currentState = SecurityState.TRIGGERED;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     let payload: any;
     bus.on(EventType.TRIP_CANCELLED, (p) => {
       payload = p;
@@ -207,7 +202,7 @@ describe('TripHandler', async () => {
 
   describe('resetTripSwitches', () => {
     it('resets global trip switch', () => {
-      const globalChar = services.tripSwitchService.getCharacteristic();
+      const globalChar = services.tripSwitchService.getCharacteristic('On' as any)!;
       globalChar.value = true;
 
       tripHandler.resetTripSwitches();
@@ -216,10 +211,10 @@ describe('TripHandler', async () => {
     });
 
     it('resets mode-specific trip switches', () => {
-      const homeChar = services.tripHomeSwitchService.getCharacteristic();
-      const awayChar = services.tripAwaySwitchService.getCharacteristic();
-      const nightChar = services.tripNightSwitchService.getCharacteristic();
-      const overrideChar = services.tripOverrideSwitchService.getCharacteristic();
+      const homeChar = services.tripHomeSwitchService.getCharacteristic('On' as any)!;
+      const awayChar = services.tripAwaySwitchService.getCharacteristic('On' as any)!;
+      const nightChar = services.tripNightSwitchService.getCharacteristic('On' as any)!;
+      const overrideChar = services.tripOverrideSwitchService.getCharacteristic('On' as any)!;
       homeChar.value = true;
       awayChar.value = true;
       nightChar.value = true;
@@ -234,7 +229,7 @@ describe('TripHandler', async () => {
     });
 
     it('does not touch switches that are already off', () => {
-      const globalChar = services.tripSwitchService.getCharacteristic();
+      const globalChar = services.tripSwitchService.getCharacteristic('On' as any)!;
       globalChar.value = false;
 
       tripHandler.resetTripSwitches();


### PR DESCRIPTION
Fixes TypeScript compilation errors in trip-handler.test.ts where getCharacteristic() was called without the required argument. Also adds npm run build to the CI workflow to catch type errors before publish.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Ensured the package build runs before packing to make releases more reliable.

* **Tests**
  * Improved trip-switch reset tests for clearer, more robust assertions.
  * Relaxed strict linting for test files to allow necessary test scaffolding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->