### PR TITLE
fix: reset trip state properly when system is disarmed (fixes #905)

### DIFF
--- a/src/handlers/state-handler.ts
+++ b/src/handlers/state-handler.ts
@@ -200,6 +200,7 @@ export class StateHandler {
       this.sensorHandler.pulseResetMotionSensor();
     }
 
+    this.state.isTripping = false;
     this.state.isKnocked = false;
   }
 
@@ -210,10 +211,13 @@ export class StateHandler {
       if (this.options.testMode) {
         return;
       }
+    } else {
+      // Notify TripHandler to reset trip switches on any non-triggered state change.
+      // (Do not reset when entering TRIGGERED — the trip switch should remain ON
+      // to reflect the active sensor / cause of the alarm.)
+      this.bus.emit(EventType.RESET_TRIP_SWITCHES, {});
     }
 
-    // Notify TripHandler to reset trip switches on any state change.
-    this.bus.emit(EventType.RESET_TRIP_SWITCHES, {});
     this.bus.emit(EventType.CURRENT_CHANGED, { state: this.state.currentState, origin });
   }
 

--- a/src/tests/state-handler.test.ts
+++ b/src/tests/state-handler.test.ts
@@ -6,6 +6,7 @@ import type { SecuritySystemOptions } from '../interfaces/options-interface.js';
 import type { ServiceRegistry } from '../interfaces/service-registry-interface.js';
 import type { StorageService } from '../services/storage-service.js';
 import type { AudioService } from '../services/audio-service.js';
+import { EventType } from '../types/event-type.js';
 
 // ── Minimal mocks ─────────────────────────────────────────────────────────────
 
@@ -216,5 +217,87 @@ describe('StateHandler.updateTargetState', async () => {
     const result = handler.updateTargetState(SecurityState.HOME, OriginType.REGULAR_SWITCH, 0);
     expect(result.success).toBe(true);
     expect(state.targetState).toBe(SecurityState.HOME);
+  });
+});
+
+// ── Regression: RESET_TRIP_SWITCHES on TRIGGERED ───────────────────────────────
+// Issue 905: Trip Switch was being reset to OFF when the alarm triggered,
+// hiding the active sensor from the user.
+
+describe('StateHandler.setCurrentState - RESET_TRIP_SWITCHES', async () => {
+  const { StateHandler } = await import('../handlers/state-handler.js');
+  const { EventBusService } = await import('../services/event-bus-service.js');
+
+  it('does not emit RESET_TRIP_SWITCHES when entering TRIGGERED', () => {
+    const state = makeState({ currentState: SecurityState.NIGHT });
+    const bus = new EventBusService();
+    const spy = vi.fn();
+    bus.on(EventType.RESET_TRIP_SWITCHES, spy);
+
+    const handler = new StateHandler(
+      makeServices(), state, makeOptions(), {} as any,
+      makeMockLog() as any, bus, makeStorage(), makeAudio(),
+      makeTimers(), makeMockSensor() as any,
+    );
+
+    handler.setCurrentState(SecurityState.TRIGGERED, OriginType.EXTERNAL);
+
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('still emits RESET_TRIP_SWITCHES when entering a non-TRIGGERED state', () => {
+    const state = makeState({ currentState: SecurityState.TRIGGERED });
+    const bus = new EventBusService();
+    const spy = vi.fn();
+    bus.on(EventType.RESET_TRIP_SWITCHES, spy);
+
+    const handler = new StateHandler(
+      makeServices(), state, makeOptions(), {} as any,
+      makeMockLog() as any, bus, makeStorage(), makeAudio(),
+      makeTimers(), makeMockSensor() as any,
+    );
+
+    handler.setCurrentState(SecurityState.NIGHT, OriginType.EXTERNAL);
+
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ── Regression: isTripping reset on target state change ───────────────────────
+// Issue 905: isTripping was not being reset when the user changed the target
+// mode, causing stale trip state after OFF disarm + re-arm.
+
+describe('StateHandler.updateTargetState - isTripping reset', async () => {
+  const { StateHandler } = await import('../handlers/state-handler.js');
+  const { EventBusService } = await import('../services/event-bus-service.js');
+
+  it('resets isTripping to false when target state changes to a different mode', () => {
+    const state = makeState({ currentState: SecurityState.HOME, isTripping: true });
+    const handler = new StateHandler(
+      makeServices(), state, makeOptions(), {} as any,
+      makeMockLog() as any, new EventBusService(), makeStorage(), makeAudio(),
+      makeTimers(), makeMockSensor() as any,
+    );
+
+    handler.updateTargetState(SecurityState.AWAY, OriginType.INTERNAL, 0);
+
+    expect(state.isTripping).toBe(false);
+  });
+
+  it('resets isTripping to false when disarming from TRIGGERED to OFF', () => {
+    const state = makeState({
+      currentState: SecurityState.TRIGGERED,
+      targetState: SecurityState.NIGHT,
+      isTripping: true,
+    });
+    const handler = new StateHandler(
+      makeServices(), state, makeOptions(), {} as any,
+      makeMockLog() as any, new EventBusService(), makeStorage(), makeAudio(),
+      makeTimers(), makeMockSensor() as any,
+    );
+
+    handler.updateTargetState(SecurityState.OFF, OriginType.INTERNAL, 0);
+
+    expect(state.isTripping).toBe(false);
   });
 });


### PR DESCRIPTION
## Bug description

Fixes #905

Two issues were identified:

### Issue 1: Alarm re-triggers immediately after OFF → re-arm

When handleTargetStateChange() was called (e.g., switching to OFF), the trigger timer was cleared via esetTimers() but \state.isTripping\ was never reset to \alse\. This left stale trip state that could interfere with re-arming logic.

### Issue 2: Trip Switch not visible as ON when alarm triggers

\handleCurrentStateChange()\ emitted \RESET_TRIP_SWITCHES\ unconditionally for ALL state transitions, including when entering \TRIGGERED\. This immediately set the Trip Switch characteristic to OFF in HomeKit, so users never saw which sensor caused the alarm.

## Root cause

Both issues were introduced in the TypeScript migration (commit 277948d). The old single-file JavaScript codebase did not have the event-bus-based architecture with \RESET_TRIP_SWITCHES\.

## Changes

### \src/handlers/state-handler.ts\

1. Moved \RESET_TRIP_SWITCHES\ emission into the \lse\ branch of the TRIGGERED check in \handleCurrentStateChange()\ — trip switches now stay ON when the alarm is active.
2. Added \	his.state.isTripping = false\ in \handleTargetStateChange()\ — ensures trip state is properly cleaned up when the target mode changes.

### \src/tests/state-handler.test.ts\

Added 4 regression tests:
- Verifies \RESET_TRIP_SWITCHES\ is NOT emitted when entering TRIGGERED
- Verifies it IS still emitted for non-TRIGGERED transitions (safeguard)
- Verifies \isTripping\ is reset when target state changes
- Verifies \isTripping\ is reset when disarming from TRIGGERED to OFF