### PR TITLE
Hardcode node-version to 24 in bump-version workflow

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v6
         with:
-          node-version: ${{ vars.NPM_VERSION }}
+          node-version: 24
 
       - name: Get next version
         uses: MiguelRipoll23/get-next-version@v3.2.0


### PR DESCRIPTION
Replaces the \ars.NPM_VERSION\ variable with the hardcoded value \24\ to use Node.js 24.