### PR TITLE
fix: hardcode node version to 24 in publish workflow

### DIFF
--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -29,7 +29,7 @@ jobs:
         uses: actions/setup-node@v6
 
         with:
-          node-version: ${{ vars.NPM_VERSION }}
+          node-version: 24
           cache: "npm"
           registry-url: https://registry.npmjs.org/
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -135,7 +135,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v6
         with:
-          node-version: ${{ vars.NPM_VERSION }}
+          node-version: 24
           registry-url: https://registry.npmjs.org/
 
       - name: Install dependencies


### PR DESCRIPTION
The \ars.NPM_VERSION\ variable was undefined, causing the setup-node action to resolve to an incorrect node version and npm publish to fail with a 404.

Fixes the failed publish run: https://github.com/MiguelRipoll23/homebridge-securitysystem/actions/runs/27905715395