### PR TITLE
feat: steady-on trip/trigger sensor when seconds = 0

### DIFF
--- a/src/handlers/sensor-handler.ts
+++ b/src/handlers/sensor-handler.ts
@@ -35,11 +35,15 @@ export class SensorHandler {
   // ── Tripped sensor ─────────────────────────────────────────────────────────
 
   pulseTrippedMotionSensor(): void {
+    this.setTrippedMotionSensor(true);
+    this.scheduleReset(this.services.trippedMotionSensorService);
+  }
+
+  setTrippedMotionSensor(value: boolean): void {
     this.services.trippedMotionSensorService.updateCharacteristic(
       this.Characteristic.MotionDetected,
-      true,
+      value,
     );
-    this.scheduleReset(this.services.trippedMotionSensorService);
   }
 
   resetTrippedMotionSensor(): void {
@@ -53,11 +57,23 @@ export class SensorHandler {
   // ── Triggered sensor ───────────────────────────────────────────────────────
 
   pulseTriggeredMotionSensor(): void {
+    this.setTriggeredMotionSensor(true);
+    this.scheduleReset(this.services.triggeredMotionSensorService);
+  }
+
+  setTriggeredMotionSensor(value: boolean): void {
     this.services.triggeredMotionSensorService.updateCharacteristic(
       this.Characteristic.MotionDetected,
-      true,
+      value,
     );
-    this.scheduleReset(this.services.triggeredMotionSensorService);
+  }
+
+  resetTriggeredMotionSensor(): void {
+    const char = this.services.triggeredMotionSensorService
+      .getCharacteristic(this.Characteristic.MotionDetected);
+    if (char.value) {
+      char.updateValue(false);
+    }
   }
 
   // ── Reset sensor ───────────────────────────────────────────────────────────

--- a/src/handlers/state-handler.ts
+++ b/src/handlers/state-handler.ts
@@ -191,6 +191,7 @@ export class StateHandler {
     // Notify handlers to reset their displayed state (bus is synchronous).
     this.bus.emit(EventType.RESET_TRIP_SWITCHES, {});
     this.sensorHandler.resetTrippedMotionSensor();
+    this.sensorHandler.resetTriggeredMotionSensor();
     this.bus.emit(EventType.RESET_MODE_SWITCHES, {});
     this.bus.emit(EventType.UPDATE_MODE_SWITCHES, {});
 
@@ -223,13 +224,8 @@ export class StateHandler {
 
   private handleTriggeredState(): void {
     this.timers.clearTrippedInterval();
-
-    if (this.options.triggeredMotionSensor) {
-      this.timers.setTriggeredInterval(
-        this.options.triggeredMotionSensorSeconds * 1000,
-        () => this.sensorHandler.pulseTriggeredMotionSensor(),
-      );
-    }
+    this.sensorHandler.resetTrippedMotionSensor();
+    this.startTriggeredMotionSensor();
 
     this.timers.setResetTimer(this.options.resetMinutes * 60 * 1000, () => {
       this.log.info('Reset (Finished)');
@@ -241,6 +237,18 @@ export class StateHandler {
         this.setCurrentState(this.state.targetState, OriginType.EXTERNAL);
       }
     });
+  }
+
+  private startTriggeredMotionSensor(): void {
+    const seconds = this.options.triggeredMotionSensorSeconds;
+    if (seconds === 0) {
+      this.sensorHandler.setTriggeredMotionSensor(true);
+    } else {
+      this.timers.setTriggeredInterval(
+        seconds * 1000,
+        () => this.sensorHandler.pulseTriggeredMotionSensor(),
+      );
+    }
   }
 
   private handleArmingState(): void {

--- a/src/handlers/trip-handler.ts
+++ b/src/handlers/trip-handler.ts
@@ -167,11 +167,7 @@ export class TripHandler {
     this.log.info('Security System (Tripped)');
 
     if (this.options.trippedMotionSensor) {
-      this.sensorHandler.pulseTrippedMotionSensor();
-      this.timers.setTrippedInterval(
-        this.options.trippedMotionSensorSeconds * 1000,
-        () => this.sensorHandler.pulseTrippedMotionSensor(),
-      );
+      this.startTrippedMotionSensor();
     }
 
     const triggerSeconds = this.resolveTriggerSeconds();
@@ -185,6 +181,19 @@ export class TripHandler {
 
     if (triggerSeconds > 0) {
       this.bus.emit(EventType.WARNING, { origin, triggerSeconds });
+    }
+  }
+
+  private startTrippedMotionSensor(): void {
+    const seconds = this.options.trippedMotionSensorSeconds;
+    if (seconds === 0) {
+      this.sensorHandler.setTrippedMotionSensor(true);
+    } else {
+      this.sensorHandler.pulseTrippedMotionSensor();
+      this.timers.setTrippedInterval(
+        seconds * 1000,
+        () => this.sensorHandler.pulseTrippedMotionSensor(),
+      );
     }
   }
 

--- a/src/tests/state-handler.test.ts
+++ b/src/tests/state-handler.test.ts
@@ -116,7 +116,11 @@ function makeTimers() {
 function makeMockSensor() {
   return {
     resetArmingMotionSensor: vi.fn(),
+    setTrippedMotionSensor: vi.fn(),
     resetTrippedMotionSensor: vi.fn(),
+    pulseTriggeredMotionSensor: vi.fn(),
+    setTriggeredMotionSensor: vi.fn(),
+    resetTriggeredMotionSensor: vi.fn(),
     pulseResetMotionSensor: vi.fn(),
     updateArmingMotionSensor: vi.fn(),
   };
@@ -299,5 +303,67 @@ describe('StateHandler.updateTargetState - isTripping reset', async () => {
     handler.updateTargetState(SecurityState.OFF, OriginType.INTERNAL, 0);
 
     expect(state.isTripping).toBe(false);
+  });
+});
+
+// ── Triggered motion sensor behavior ─────────────────────────────────────────
+
+describe('StateHandler.setCurrentState - triggered motion sensor', async () => {
+  const { StateHandler } = await import('../handlers/state-handler.js');
+  const { EventBusService } = await import('../services/event-bus-service.js');
+
+  it('starts triggered sensor steady-on when triggeredMotionSensorSeconds = 0', () => {
+    const state = makeState({ currentState: SecurityState.NIGHT });
+    const bus = new EventBusService();
+    const sensor = makeMockSensor() as any;
+    const timers = makeTimers();
+
+    const handler = new StateHandler(
+      makeServices(), state,
+      makeOptions({ triggeredMotionSensor: true, triggeredMotionSensorSeconds: 0 }),
+      {} as any, makeMockLog() as any, bus, makeStorage(), makeAudio(),
+      timers, sensor,
+    );
+
+    handler.setCurrentState(SecurityState.TRIGGERED, OriginType.EXTERNAL);
+
+    expect(sensor.setTriggeredMotionSensor).toHaveBeenCalledWith(true);
+    expect(sensor.pulseTriggeredMotionSensor).not.toHaveBeenCalled();
+    expect(timers.setTriggeredInterval).not.toHaveBeenCalled();
+  });
+
+  it('pulses triggered sensor with interval when triggeredMotionSensorSeconds > 0', () => {
+    const state = makeState({ currentState: SecurityState.NIGHT });
+    const bus = new EventBusService();
+    const sensor = makeMockSensor() as any;
+    const timers = makeTimers();
+
+    const handler = new StateHandler(
+      makeServices(), state,
+      makeOptions({ triggeredMotionSensor: true, triggeredMotionSensorSeconds: 10 }),
+      {} as any, makeMockLog() as any, bus, makeStorage(), makeAudio(),
+      timers, sensor,
+    );
+
+    handler.setCurrentState(SecurityState.TRIGGERED, OriginType.EXTERNAL);
+
+    expect(timers.setTriggeredInterval).toHaveBeenCalledWith(10000, expect.any(Function));
+    expect(sensor.setTriggeredMotionSensor).not.toHaveBeenCalled();
+  });
+
+  it('resets tripped motion sensor when entering TRIGGERED', () => {
+    const state = makeState({ currentState: SecurityState.NIGHT });
+    const bus = new EventBusService();
+    const sensor = makeMockSensor() as any;
+
+    const handler = new StateHandler(
+      makeServices(), state, makeOptions(), {} as any,
+      makeMockLog() as any, bus, makeStorage(), makeAudio(),
+      makeTimers(), sensor,
+    );
+
+    handler.setCurrentState(SecurityState.TRIGGERED, OriginType.EXTERNAL);
+
+    expect(sensor.resetTrippedMotionSensor).toHaveBeenCalled();
   });
 });

--- a/src/tests/trip-handler.test.ts
+++ b/src/tests/trip-handler.test.ts
@@ -95,6 +95,7 @@ describe('TripHandler', async () => {
   let tripHandler: any;
   const mockSensorHandler = {
     pulseTrippedMotionSensor: vi.fn(),
+    setTrippedMotionSensor: vi.fn(),
     resetTrippedMotionSensor: vi.fn(),
   };
   const mockAudio = { stop: vi.fn(), play: vi.fn(), attachToBus: vi.fn() };
@@ -147,6 +148,51 @@ describe('TripHandler', async () => {
     state.currentState = SecurityState.HOME;
     const result = tripHandler.updateTripSwitch(true, OriginType.REGULAR_SWITCH, false);
     expect(result.success).toBe(true);
+  });
+
+  describe('tripped motion sensor', () => {
+    it('starts steady-on when trippedMotionSensorSeconds = 0', () => {
+      const handler = new TripHandler(
+        services, state,
+        makeOptions({ trippedMotionSensor: true, trippedMotionSensorSeconds: 0 }),
+        {} as any, { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() } as any,
+        bus, mockAudio as any, mockSensorHandler as any, mockTimers,
+      );
+
+      handler.updateTripSwitch(true, OriginType.REGULAR_SWITCH, false);
+
+      expect(mockSensorHandler.setTrippedMotionSensor).toHaveBeenCalledWith(true);
+      expect(mockSensorHandler.pulseTrippedMotionSensor).not.toHaveBeenCalled();
+      expect(mockTimers.setTrippedInterval).not.toHaveBeenCalled();
+    });
+
+    it('pulses with interval when trippedMotionSensorSeconds > 0', () => {
+      const handler = new TripHandler(
+        services, state,
+        makeOptions({ trippedMotionSensor: true, trippedMotionSensorSeconds: 10 }),
+        {} as any, { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() } as any,
+        bus, mockAudio as any, mockSensorHandler as any, mockTimers,
+      );
+
+      handler.updateTripSwitch(true, OriginType.REGULAR_SWITCH, false);
+
+      expect(mockSensorHandler.pulseTrippedMotionSensor).toHaveBeenCalled();
+      expect(mockTimers.setTrippedInterval).toHaveBeenCalledWith(10000, expect.any(Function));
+      expect(mockSensorHandler.setTrippedMotionSensor).not.toHaveBeenCalled();
+    });
+
+    it('resets tripped sensor on cancelTrip', () => {
+      const handler = new TripHandler(
+        services, state,
+        makeOptions({ trippedMotionSensor: true }),
+        {} as any, { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() } as any,
+        bus, mockAudio as any, mockSensorHandler as any, mockTimers,
+      );
+
+      handler.updateTripSwitch(false, OriginType.REGULAR_SWITCH, false);
+
+      expect(mockSensorHandler.resetTrippedMotionSensor).toHaveBeenCalled();
+    });
   });
 
   it('cancels trip and stops audio', () => {


### PR DESCRIPTION
When \	rippedMotionSensorSeconds\ or \	riggeredMotionSensorSeconds\ is set to \

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved code organization for motion sensor handling to streamline state management and reduce code duplication.

* **Tests**
  * Expanded test coverage for motion sensor behavior during security state transitions and trip activation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->