### PR TITLE
fix: update publish workflow to use pnpm

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -132,6 +132,11 @@ jobs:
       - name: Checkout branch
         uses: actions/checkout@v7
 
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6.0.9
+        with:
+          version: latest
+
       - name: Setup node
         uses: actions/setup-node@v6
         with:
@@ -139,7 +144,7 @@ jobs:
           registry-url: https://registry.npmjs.org/
 
       - name: Install dependencies
-        run: npm ci
+        run: pnpm install --frozen-lockfile
 
       - name: Get version
         run: |
@@ -147,4 +152,4 @@ jobs:
 
       - name: Publish package
         run: |
-          npm publish --access public --provenance --tag "$(if [[ $NPM_VERSION == *-* ]]; then echo beta; else echo latest; fi)"
+          pnpm publish --access public --no-git-checks --provenance --tag "$(if [[ $NPM_VERSION == *-* ]]; then echo beta; else echo latest; fi)"


### PR DESCRIPTION
## Root Cause

The \publish.yml\ workflow used \
pm ci\ at line 142, but \package-lock.json\ was deleted during the pnpm migration (commit \chore/update-deps-ts7\). The project now uses \pnpm-lock.yaml\.

## Fix

Updated \publish.yml\ to:
- Add \pnpm/action-setup\ step (matching \uild-package.yml\)
- Use \pnpm install --frozen-lockfile\ instead of \
pm ci\
- Use \pnpm publish --no-git-checks\ instead of \
pm publish\

Closes the publish workflow failure seen in run #29154210468.