### PR TITLE
feat: use full URL per webhook event (remove base URL)

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -471,83 +471,85 @@
         "required": false,
         "placeholder": "your-api-key"
       },
-      "webhook_url": {
-        "title": "Base URL",
-        "description": "",
-        "type": "string",
-        "required": false,
-        "format": "uri",
-        "placeholder": "http://localhost"
-      },
       "webhook_target_home": {
         "title": "Target Mode: Home",
         "description": "",
         "type": "string",
         "required": false,
-        "placeholder": "/target/home"
+        "format": "uri",
+        "placeholder": "http://localhost/target/home"
       },
       "webhook_target_away": {
         "title": "Target Mode: Away",
         "description": "",
         "type": "string",
         "required": false,
-        "placeholder": "/target/away"
+        "format": "uri",
+        "placeholder": "http://localhost/target/away"
       },
       "webhook_target_night": {
         "title": "Target Mode: Night",
         "description": "",
         "type": "string",
         "required": false,
-        "placeholder": "/target/night"
+        "format": "uri",
+        "placeholder": "http://localhost/target/night"
       },
       "webhook_target_off": {
         "title": "Target Mode: Off",
         "description": "",
         "type": "string",
         "required": false,
-        "placeholder": "/target/off"
+        "format": "uri",
+        "placeholder": "http://localhost/target/off"
       },
       "webhook_current_home": {
         "title": "Current Mode: Home",
         "description": "",
         "type": "string",
         "required": false,
-        "placeholder": "/current/home"
+        "format": "uri",
+        "placeholder": "http://localhost/current/home"
       },
       "webhook_current_away": {
         "title": "Current Mode: Away",
         "description": "",
         "type": "string",
         "required": false,
-        "placeholder": "/current/away"
+        "format": "uri",
+        "placeholder": "http://localhost/current/away"
       },
       "webhook_current_night": {
         "title": "Current Mode: Night",
         "description": "",
         "type": "string",
         "required": false,
-        "placeholder": "/current/night"
+        "format": "uri",
+        "placeholder": "http://localhost/current/night"
       },
       "webhook_current_off": {
         "title": "Current Mode: Off",
         "description": "",
         "type": "string",
         "required": false,
-        "placeholder": "/current/off"
+        "format": "uri",
+        "placeholder": "http://localhost/current/off"
       },
       "webhook_current_warning": {
         "title": "Current Event: Warning",
         "description": "",
         "type": "string",
         "required": false,
-        "placeholder": "/current/warning"
+        "format": "uri",
+        "placeholder": "http://localhost/current/warning"
       },
       "webhook_current_triggered": {
         "title": "Current Mode: Triggered",
         "description": "",
         "type": "string",
         "required": false,
-        "placeholder": "/current/triggered"
+        "format": "uri",
+        "placeholder": "http://localhost/current/triggered"
       },
       "command_target_home": {
         "title": "Target Mode: Home",
@@ -965,7 +967,6 @@
       "expandable": true,
       "expanded": false,
       "items": [
-        "webhook_url",
         "webhook_target_home",
         "webhook_target_away",
         "webhook_target_night",

--- a/src/interfaces/options-interface.ts
+++ b/src/interfaces/options-interface.ts
@@ -115,7 +115,6 @@ export interface SecuritySystemOptions {
   commandCurrentTriggered: string | null;
 
   // Webhooks
-  webhookUrl: string | null;
   webhookTargetHome: string | null;
   webhookTargetAway: string | null;
   webhookTargetNight: string | null;

--- a/src/security-system.ts
+++ b/src/security-system.ts
@@ -182,8 +182,5 @@ export class SecuritySystem implements AccessoryPlugin {
     if (this.options.proxyMode) {
       this.log.info('Proxy mode (Enabled)');
     }
-    if (this.options.webhookUrl) {
-      this.log.info(`Webhook (${this.options.webhookUrl})`);
-    }
   }
 }

--- a/src/services/configuration-service.ts
+++ b/src/services/configuration-service.ts
@@ -192,7 +192,6 @@ export class ConfigurationService {
       commandCurrentTriggered: this.str(raw, 'command_current_triggered'),
 
       // Webhooks
-      webhookUrl: this.str(raw, 'webhook_url'),
       webhookTargetHome: this.str(raw, 'webhook_target_home'),
       webhookTargetAway: this.str(raw, 'webhook_target_away'),
       webhookTargetNight: this.str(raw, 'webhook_target_night'),

--- a/src/services/webhook-service.ts
+++ b/src/services/webhook-service.ts
@@ -28,25 +28,19 @@ export class WebhookService {
   }
 
   send(type: string, stateOrMode: SecurityState | string, origin: OriginType): void {
-    if (!this.options.webhookUrl) {
-      this.log.debug('Webhook base URL not set.');
-      return;
-    }
-
     if (this.options.proxyMode && origin === OriginType.EXTERNAL) {
       this.log.debug('Webhook bypassed (proxy mode).');
       return;
     }
 
-    const urlPath = this.resolvePath(type, stateOrMode);
-    if (!urlPath) {
-      this.log.debug(`Webhook path for ${type}/${stateOrMode} not set.`);
+    const urlTemplate = this.resolveUrl(type, stateOrMode);
+    if (!urlTemplate) {
+      this.log.debug(`Webhook URL for ${type}/${stateOrMode} not set.`);
       return;
     }
 
     const currentMode = stateToMode(this.state.currentState);
-    const finalPath = urlPath.replace('${currentMode}', currentMode);
-    const url = this.options.webhookUrl + finalPath;
+    const url = urlTemplate.replace('${currentMode}', currentMode);
 
     fetch(url)
       .then(res => {
@@ -56,12 +50,12 @@ export class WebhookService {
         this.log.info('Webhook event (Sent)');
       })
       .catch(err => {
-        this.log.error(`Webhook request failed (${finalPath})`);
+        this.log.error(`Webhook request failed (${url})`);
         this.log.error(String(err));
       });
   }
 
-  private resolvePath(type: string, stateOrMode: SecurityState | string): string | null {
+  private resolveUrl(type: string, stateOrMode: SecurityState | string): string | null {
     const s = stateOrMode;
     const o = this.options;
 


### PR DESCRIPTION
## What

Removes the `webhook_url` base URL config option. Each webhook event now takes its own **full URL**, just like the shell command hooks do.

## Why

Users had to configure a base URL plus 10 path suffixes, and every webhook had to live on the same host. Full URLs per event are simpler and more flexible — each event can point at a different host/service.

## Changes

- **`config.schema.json`** — removed `webhook_url`, switched each webhook field to `format: uri` with full-URL placeholders (e.g. `http://localhost/target/home`).
- **`webhook-service.ts`** — dropped the base-URL concatenation; each resolved value is fetched directly. The `${currentMode}` placeholder substitution still works on the full URL.
- **`options-interface.ts` / `configuration-service.ts`** — removed `webhookUrl`.
- **`security-system.ts`** — removed the base-URL startup log line.

## Breaking change

Existing configs with `webhook_url` + paths must be migrated to full URLs in each `webhook_*` field.