### PR TITLE
docs: update AGENTS.md to match current architecture

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,13 +6,14 @@ This document defines the architecture, naming conventions, and rules that all c
 
 ## Project Overview
 
-`homebridge-securitysystem` is a Homebridge v2 accessory plugin (not a platform plugin) that exposes a fully-featured security system to HomeKit. It is written in TypeScript with ESM modules.
+`homebridge-securitysystem` is a Homebridge accessory plugin (not a platform plugin) that exposes a fully-featured security system to HomeKit. It is written in TypeScript with ESM modules.
 
 The plugin:
-- Exposes one `SecuritySystem` HAP service plus up to 22 optional switch/sensor accessories.
-- Uses an event-driven architecture: core state changes emit domain events; side-effect services (audio, webhook, command) listen and react.
+- Exposes one `SecuritySystem` HAP service plus a configurable set of optional switch/sensor accessories (trip, mode, arming-lock, and audio switches; motion sensors).
+- Uses an event-driven architecture: core state changes emit domain events; side-effect services (audio, webhook, command, MQTT) listen and react.
 - Uses an abstract `Condition` class hierarchy to encapsulate all blocking-logic decisions.
-- Provides an optional Hono HTTP server for remote control.
+- Provides an optional Hono HTTP server (zod-validated routes with OpenAPI and Scalar docs) for remote control.
+- Optionally publishes status updates over MQTT.
 
 ---
 
@@ -24,9 +25,12 @@ src/
   conditions/        Abstract Condition base + concrete condition classes
   constants/         Compile-time constants (no logic)
   handlers/          Stateful handlers wired by security-system.ts
+  homekit/           HomeKit service construction + characteristic registration
   interfaces/        TypeScript interfaces (plain object shapes)
-  services/          Stateful services (audio, webhook, command, storage, server, event bus)
+  schemas/           Zod schemas for HTTP server request/response validation
+  services/          Stateful services (audio, webhook, command, MQTT, storage, server, event bus)
   tests/             Vitest test suites
+  timers/            Centralised timer/interval ownership (TimerManager)
   types/             TypeScript enums and type aliases
   utils/             Pure utility functions
   index.ts           Homebridge plugin entry point
@@ -44,6 +48,9 @@ src/
 | `constants/` | `const` objects, literal values | Logic, mutable state |
 | `utils/` | Pure functions with no side effects | Classes, state, I/O |
 | `conditions/` | Classes extending `Condition` | Handlers, services |
+| `schemas/` | Zod schemas for HTTP validation | Logic, I/O |
+| `timers/` | Timer/interval ownership (`TimerManager`) | Timer logic embedded in handlers |
+| `homekit/` | HomeKit service construction, characteristic registration | State-machine logic |
 | `services/` | Stateful singleton classes, I/O | Embedded types, enums, interfaces |
 | `handlers/` | State-machine logic classes | Embedded types, enums, interfaces |
 
@@ -61,9 +68,13 @@ All filenames use **kebab-case** with a mandatory suffix describing their kind:
 | Interface | `-interface.ts` | `system-state-interface.ts` |
 | Constant object | `-constant.ts` | `homekit-constant.ts` |
 | Utility functions | `-util.ts` | `state-util.ts` |
+| Zod schema | `-schema.ts` | `error-schema.ts` |
 | Service class | `-service.ts` | `audio-service.ts` |
 | Handler class | `-handler.ts` | `state-handler.ts` |
 | Condition class | `-condition.ts` | `double-knock-condition.ts` |
+| HomeKit registrar class | `-registrar.ts` | `homekit-registrar.ts` |
+| Factory function | `-factory.ts` | `service-factory.ts` |
+| Timer manager class | `-manager.ts` | `timer-manager.ts` |
 | Test suite | `.test.ts` | `conditions.test.ts` |
 
 ---
@@ -109,7 +120,7 @@ Forbidden examples and their correct replacements:
 ### Class Names
 
 - PascalCase, no abbreviations.
-- Suffix matches the layer: `...Service`, `...Handler`, `...Condition`.
+- Suffix matches the layer: `...Service`, `...Handler`, `...Condition`, `...Registrar`, `...Manager`.
 
 ### Enum Members
 
@@ -124,17 +135,17 @@ Forbidden examples and their correct replacements:
 
 ## Architecture: Event-Driven Side Effects
 
-The core state machine (`StateHandler`, `TripHandler`, `SwitchHandler`) never calls side-effect services directly. Instead it emits domain events via `EventBusService`:
+The core state machine (`StateHandler`, `TripHandler`, `SwitchHandler`) never calls the bus-attached side-effect services directly. Instead it emits domain events via `EventBusService`:
 
 ```
 StateHandler → bus.emit(EventType.CURRENT_CHANGED, payload)
-                         ↓              ↓              ↓
-                  AudioService   WebhookService  CommandService
+                         ↓              ↓              ↓              ↓
+                  AudioService   WebhookService  CommandService  MqttService
 ```
 
-Each side-effect service calls `attachToBus(bus)` during construction in `security-system.ts`.
+`AudioService` and `StorageService` are constructor-injected into the handlers that need them; `WebhookService`, `CommandService`, and `MqttService` are purely event-driven and call `attachToBus(bus)` during construction in `security-system.ts`.
 
-**New side effects must follow this pattern** — never add direct calls from handlers to services.
+**New side effects must follow this pattern** — never add direct calls from handlers to services. The MQTT client is disconnected on shutdown via an `api.on('shutdown', ...)` hook wired in `security-system.ts`.
 
 Events and their payload types are defined in `src/types/event-type.ts`. The mapping from event to payload is in `src/types/event-payload-map-type.ts`.
 
@@ -147,24 +158,36 @@ All trip-blocking decisions use the `Condition` abstract base class:
 ```typescript
 abstract class Condition {
   abstract readonly name: string;
+  protected _failureReason: string | undefined;
+  get failureReason(): string | undefined;
+  protected clearFailureReason(): void;
   abstract evaluate(context: ConditionContext): boolean;
 }
 ```
 
-`evaluate` returns `true` to **block** the action, `false` to **allow** it.
+`evaluate` returns `true` to **block** the action, `false` to **allow** it. Implementations must call `this.clearFailureReason()` at the top of `evaluate()` and set `this._failureReason` before returning `true`; callers read it via `failureReason` to surface the blocking reason to the user.
 
-Conditions are instantiated once inside `TripHandler` and evaluated in order. To add a new blocking rule, create a new file in `conditions/`, extend `Condition`, and add it to `TripHandler`.
+The context is the `ConditionContext` interface in `src/interfaces/condition-context-interface.ts` (`state`, `services`, `options`, `value`, `origin`, `log`).
+
+Conditions are instantiated once inside `TripHandler` and evaluated in order: `NotArmedCondition`, `ArmingInProgressCondition`, `DoubleKnockCondition`, `AlreadyTriggeredCondition`, `TriggerAlreadyRunningCondition`. To add a new blocking rule, create a new file in `conditions/`, extend `Condition`, and add it to the list in `TripHandler`.
 
 ---
 
-## Architecture: Circular Dependency Resolution
+## Architecture: Handler Wiring & Dependency Resolution
 
-`StateHandler` ↔ `TripHandler` and `StateHandler` ↔ `SwitchHandler` are mutually dependent. This is resolved with **setter injection**:
+Handlers are constructed in a fixed order in `security-system.ts` so no two handlers hold constructor references to each other:
 
-1. Construct all handlers independently.
-2. Wire them with `setHandlers()` / `setStateHandler()` after all instances exist.
+1. `SensorHandler` (leaf — no handler dependencies)
+2. `StateHandler` (depends on `SensorHandler`)
+3. `SwitchHandler` (one-way constructor dependency on `StateHandler`)
+4. `TripHandler` (depends on `SensorHandler`; no `StateHandler` reference)
 
-Do not introduce `new` calls between these classes at construction time.
+Coordination between `StateHandler` ↔ `TripHandler` and `StateHandler` ↔ `SwitchHandler` is done through the event bus rather than setter injection:
+
+- `switchHandler.subscribeToStateEvents(bus)` registers listeners for `RESET_MODE_SWITCHES` / `UPDATE_MODE_SWITCHES`.
+- `security-system.ts` subscribes to `TRIGGER_FIRED` (calls `stateHandler.setCurrentState(TRIGGERED, origin)`) and `TRIP_CANCELLED` (falls back to OFF or `stateHandler.resetTimers()`).
+
+Do not introduce constructor cycles or setter injection between handlers — wire cross-handler coordination through the bus.
 
 ---
 
@@ -192,23 +215,31 @@ if (!value) {
 - Validate only at system boundaries (config parsing, HTTP input, external storage).
 - Do not add defensive null-checks for values guaranteed by the type system.
 
+### Timers
+State-machine timers and intervals (arm, trigger, pause, double-knock, reset, tripped/triggered sensor polling) are owned by `TimerManager` (`src/timers/timer-manager.ts`). Handlers call its `set...Timer()` / `clear...Timer()` methods instead of creating raw timer handles, and never store timer handles in `SystemState`. Short-lived one-off delays (sensor pulses, HTTP-side trip deferral) may use raw `setTimeout`.
+
 ---
 
 ## Testing
 
-- Framework: **Vitest** (`npm test`).
+- Package manager is **pnpm** (`pnpm-lock.yaml`).
+- Framework: **Vitest** (`pnpm test`).
+- Lint with **Oxlint** (`pnpm run lint`); typecheck with `pnpm run typecheck` (`tsc --noEmit`); build with `pnpm run build`.
 - Test files live in `src/tests/` and are named `<subject>.test.ts`.
 - Tests cover: conditions (all blocking paths), handler logic, and event-driven interactions.
 - Mock only what is strictly necessary. Prefer structural mocks over full mock libraries.
 - Do not test private methods directly — test through the public API.
+- The HTTP server exposes its Hono app via `get app` for integration tests.
 
 ---
 
 ## Adding a New Feature
 
 1. **Types/interfaces first** — create files in `types/` or `interfaces/` before writing logic.
-2. **Condition** — if the feature blocks a trip, add a `Condition` subclass.
-3. **Service** — if the feature is a side effect, implement `attachToBus(bus)` and wire in `security-system.ts`.
-4. **Handler** — if the feature changes state-machine logic, modify the relevant handler.
-5. **Tests** — add a test covering the happy path and the main blocking/edge case.
-6. **No abbreviations** — all new identifiers must be fully spelled out.
+2. **Condition** — if the feature blocks a trip, add a `Condition` subclass and register it in `TripHandler`.
+3. **Timer** — if the feature needs delays or polling, add methods to `TimerManager` rather than raw `setTimeout`/`setInterval` calls.
+4. **Service** — if the feature is a side effect, implement `attachToBus(bus)` and wire it in `security-system.ts`. If it holds a connection (e.g. MQTT), clean it up on `api.on('shutdown')`.
+5. **HTTP endpoint** — if the feature is exposed over the server, add a zod schema in `schemas/` and a route in `server-service.ts`.
+6. **Handler** — if the feature changes state-machine logic, modify the relevant handler and coordinate via the event bus.
+7. **Tests** — add a test covering the happy path and the main blocking/edge case.
+8. **No abbreviations** — all new identifiers must be fully spelled out.


### PR DESCRIPTION
## Summary

Updates `AGENTS.md` so it reflects the current state of the codebase instead of the outdated structure it described.

## What changed

- **Source layout** — added the `homekit/`, `schemas/`, and `timers/` directories, and the `MqttService` in `services/`.
- **Layer rules** — new rows for `schemas/`, `timers/`, and `homekit/`.
- **File naming conventions** — added `-schema.ts`, `-registrar.ts`, `-factory.ts`, and `-manager.ts` suffixes.
- **Event-driven side effects** — the diagram now includes `MqttService`; clarified that audio/storage are constructor-injected while webhook/command/MQTT attach to the bus; noted the MQTT shutdown hook.
- **Condition system** — documented the `failureReason`/`clearFailureReason()` contract and the `ConditionContext` interface, and listed the conditions currently evaluated in `TripHandler`.
- **Handler wiring** — replaced the outdated setter-injection section with the current construction-order + event-bus wiring (`subscribeToStateEvents`, `TRIGGER_FIRED`, `TRIP_CANCELLED`).
- **Code style** — added a Timers section describing `TimerManager` ownership.
- **Testing** — pnpm is the package manager; documented `pnpm test`, `pnpm run lint` (Oxlint), `pnpm run typecheck`, and `pnpm run build`.
- **Adding a New Feature** — expanded checklist to cover `TimerManager`, HTTP schemas, and connection cleanup on shutdown.

## Notes

- Docs-only change; no source code touched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded development guidance for MQTT, HomeKit, services, validation, timers, event handling, and feature implementation.
  * Added documentation for tooling commands and HTTP testing access.
  * Clarified condition evaluation, failure reasons, naming conventions, and handler construction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->